### PR TITLE
feat: integrate figma redesign into production portfolio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ next-env.d.ts
 # Playwright
 test-results/
 playwright-report/
+
+# local worktrees
+.worktrees/

--- a/e2e/contact.spec.ts
+++ b/e2e/contact.spec.ts
@@ -1,124 +1,53 @@
-import { test, expect } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 
-test.describe("Contact Form", () => {
+import { mockCsrfToken } from "./support/mockCsrf";
+
+test.describe("Contact form", () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto("/");
-    // Scroll to contact section
-    await page.locator("#contact").scrollIntoViewIfNeeded();
-  });
-
-  test("should have contact form with required fields", async ({ page }) => {
-    // Check form exists
-    const form = page.locator("form");
-    await expect(form.first()).toBeVisible();
-
-    // Check for input fields (by common patterns)
-    const nameInput = page.locator(
-      'input[name="name"], input[placeholder*="name" i], input#name'
-    );
-    const emailInput = page.locator(
-      'input[name="email"], input[type="email"], input#email'
-    );
-    const messageInput = page.locator(
-      'textarea[name="message"], textarea#message, textarea'
-    );
-
-    await expect(nameInput.first()).toBeVisible();
-    await expect(emailInput.first()).toBeVisible();
-    await expect(messageInput.first()).toBeVisible();
-  });
-
-  test("should have submit button", async ({ page }) => {
-    const submitButton = page.locator(
-      'button[type="submit"], input[type="submit"], button:has-text("Send"), button:has-text("Submit")'
-    );
-
-    await expect(submitButton.first()).toBeVisible();
-  });
-
-  test("should validate required fields on empty submit", async ({ page }) => {
-    // Find and click submit without filling form
-    const submitButton = page.locator(
-      'button[type="submit"], input[type="submit"]'
-    );
-
-    if ((await submitButton.count()) > 0) {
-      await submitButton.first().click();
-
-      // Should show validation - check for any error indicators
-      // Wait a moment for validation to appear
-      await page.waitForTimeout(500);
-
-      // Look for common validation patterns
-      const hasValidation = await page
-        .locator(
-          '.error, [role="alert"], .invalid-feedback, :invalid, [aria-invalid="true"]'
-        )
-        .count();
-
-      // HTML5 validation or custom validation should have triggered
-      expect(hasValidation).toBeGreaterThanOrEqual(0);
-    }
-  });
-
-  test("should have form with security measures", async ({ page }) => {
-    // Verify form has proper structure for security
-    const form = page.locator("form").first();
-    await expect(form).toBeVisible();
-
-    // Form should have some form of validation (required fields, etc.)
-    const requiredFields = await form.locator("[required], [aria-required]").count();
-    // Having required fields indicates form validation is in place
-    expect(requiredFields).toBeGreaterThanOrEqual(0);
-  });
-
-  test("should have CSRF token field", async ({ page }) => {
-    // CSRF might be handled in JS, so just check the form structure
-    const form = page.locator("form").first();
-    await expect(form).toBeVisible();
-  });
-});
-
-test.describe("Contact Form Validation", () => {
-  test("should show error for invalid email format", async ({ page }) => {
+    await mockCsrfToken(page);
     await page.goto("/");
     await page.locator("#contact").scrollIntoViewIfNeeded();
-
-    const emailInput = page.locator('input[type="email"]').first();
-
-    if ((await emailInput.count()) > 0) {
-      await emailInput.fill("invalid-email");
-      await emailInput.blur();
-
-      // Wait for validation
-      await page.waitForTimeout(300);
-
-      // Check for invalid state
-      const isInvalid =
-        (await emailInput.getAttribute("aria-invalid")) === "true" ||
-        (await emailInput.evaluate(
-          (el) => !(el as HTMLInputElement).checkValidity()
-        ));
-
-      expect(isInvalid).toBeTruthy();
-    }
   });
 
-  test("should accept valid email format", async ({ page }) => {
-    await page.goto("/");
-    await page.locator("#contact").scrollIntoViewIfNeeded();
+  test("renders the real contact form fields", async ({ page }) => {
+    await expect(page.getByLabel("Name")).toBeVisible();
+    await expect(page.getByLabel("Email")).toBeVisible();
+    await expect(page.getByLabel("Subject")).toBeVisible();
+    await expect(page.getByLabel("Message")).toBeVisible();
+    await expect(page.getByRole("button", { name: /Send Message/i })).toBeVisible();
+  });
 
-    const emailInput = page.locator('input[type="email"]').first();
+  test("shows client-side validation messages", async ({ page }) => {
+    await page.getByRole("button", { name: /Send Message/i }).click();
 
-    if ((await emailInput.count()) > 0) {
-      await emailInput.fill("valid@example.com");
-      await emailInput.blur();
+    await expect(page.getByText("Please enter your name.")).toBeVisible();
+    await expect(page.getByText("Please enter a valid email address.")).toBeVisible();
+    await expect(page.getByText("Please enter a subject.")).toBeVisible();
+    await expect(page.getByText("Message must be at least 10 characters.")).toBeVisible();
+  });
 
-      // Should be valid
-      const isValid = await emailInput.evaluate((el) =>
-        (el as HTMLInputElement).checkValidity()
-      );
-      expect(isValid).toBeTruthy();
-    }
+  test("shows the success state after a successful submission", async ({
+    page,
+  }) => {
+    await page.route("**/api/contact/", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ success: true, message: "ok" }),
+      });
+    });
+
+    await page.getByLabel("Name").fill("Alp Talha Yazar");
+    await page.getByLabel("Email").fill("alp@example.com");
+    await page.getByLabel("Subject").fill("Backend collaboration");
+    await page
+      .getByLabel("Message")
+      .fill("I would like to discuss a backend engineering opportunity.");
+
+    await page.getByRole("button", { name: /Send Message/i }).click();
+
+    await expect(
+      page.getByText("Message received. I'll get back to you as soon as possible.")
+    ).toBeVisible();
   });
 });

--- a/e2e/language.spec.ts
+++ b/e2e/language.spec.ts
@@ -1,73 +1,56 @@
-import { test, expect } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 
-test.describe("Language Switching (i18n)", () => {
+import { mockCsrfToken } from "./support/mockCsrf";
+
+test.describe("Locale routing", () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto("/");
-    // Clear language preference
-    await page.evaluate(() => {
-      localStorage.removeItem("language");
-      document.cookie =
-        "preferred-language=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;";
-    });
+    await mockCsrfToken(page);
   });
 
-  test("should support language switching via localStorage", async ({ page }) => {
+  test("renders english on the root route", async ({ page }) => {
     await page.goto("/");
 
-    // Verify i18n system works by checking we can set and read languages
-    await page.evaluate(() => localStorage.setItem("language", "tr"));
-    await page.reload();
-
-    const storedLang = await page.evaluate(() =>
-      localStorage.getItem("language")
-    );
-    expect(storedLang).toBe("tr");
+    await expect(page.locator("html")).toHaveAttribute("lang", "en");
+    await expect(
+      page.getByRole("heading", {
+        name: /I build backend systems that stay reliable under real load\./i,
+      })
+    ).toBeVisible();
   });
 
-  test("should set html lang attribute", async ({ page }) => {
-    await page.goto("/");
+  test("renders turkish on /tr", async ({ page }) => {
+    await page.goto("/tr");
 
-    const html = page.locator("html");
-    const lang = await html.getAttribute("lang");
-
-    // Should be one of supported languages
-    expect(["en", "tr", "es"]).toContain(lang);
+    await expect(page.locator("html")).toHaveAttribute("lang", "tr");
+    await expect(
+      page.getByRole("heading", {
+        name: /Gerçek yük altında güvenilir kalan backend sistemleri geliştiriyorum\./i,
+      })
+    ).toBeVisible();
   });
 
-  test("should persist language preference in localStorage", async ({
-    page,
-  }) => {
-    await page.goto("/");
+  test("renders spanish on /es", async ({ page }) => {
+    await page.goto("/es");
 
-    // Manually set language preference
-    await page.evaluate(() => localStorage.setItem("language", "tr"));
-    await page.reload();
-
-    const storedLang = await page.evaluate(() =>
-      localStorage.getItem("language")
-    );
-    expect(storedLang).toBe("tr");
+    await expect(page.locator("html")).toHaveAttribute("lang", "es");
+    await expect(
+      page.getByRole("heading", {
+        name: /Construyo sistemas backend que siguen siendo fiables bajo carga real\./i,
+      })
+    ).toBeVisible();
   });
 
-  test("should have hreflang alternate links for SEO", async ({ page }) => {
-    await page.goto("/");
+  test("exposes real hreflang alternates", async ({ page }) => {
+    await page.goto("/tr");
 
-    // Check for alternate language links
-    const enLink = page.locator('link[rel="alternate"][hreflang="en"]');
-    const trLink = page.locator('link[rel="alternate"][hreflang="tr"]');
-    const esLink = page.locator('link[rel="alternate"][hreflang="es"]');
-
-    await expect(enLink).toBeAttached();
-    await expect(trLink).toBeAttached();
-    await expect(esLink).toBeAttached();
-  });
-
-  test("should have x-default hreflang link", async ({ page }) => {
-    await page.goto("/");
-
-    const defaultLink = page.locator(
-      'link[rel="alternate"][hreflang="x-default"]'
-    );
-    await expect(defaultLink).toBeAttached();
+    await expect(
+      page.locator('link[rel="alternate"][hreflang="en"]')
+    ).toHaveAttribute("href", "https://www.alptalha.dev/");
+    await expect(
+      page.locator('link[rel="alternate"][hreflang="tr"]')
+    ).toHaveAttribute("href", "https://www.alptalha.dev/tr/");
+    await expect(
+      page.locator('link[rel="alternate"][hreflang="es"]')
+    ).toHaveAttribute("href", "https://www.alptalha.dev/es/");
   });
 });

--- a/e2e/language.spec.ts
+++ b/e2e/language.spec.ts
@@ -29,13 +29,13 @@ test.describe("Locale routing", () => {
     ).toBeVisible();
   });
 
-  test("renders spanish on /es", async ({ page }) => {
+  test("does not expose spanish publicly", async ({ page }) => {
     await page.goto("/es");
 
-    await expect(page.locator("html")).toHaveAttribute("lang", "es");
+    await expect(page.locator("html")).toHaveAttribute("lang", "en");
     await expect(
       page.getByRole("heading", {
-        name: /Construyo sistemas backend que siguen siendo fiables bajo carga real\./i,
+        name: /Route not found\./i,
       })
     ).toBeVisible();
   });
@@ -49,8 +49,6 @@ test.describe("Locale routing", () => {
     await expect(
       page.locator('link[rel="alternate"][hreflang="tr"]')
     ).toHaveAttribute("href", "https://www.alptalha.dev/tr/");
-    await expect(
-      page.locator('link[rel="alternate"][hreflang="es"]')
-    ).toHaveAttribute("href", "https://www.alptalha.dev/es/");
+    await expect(page.locator('link[rel="alternate"][hreflang="es"]')).toHaveCount(0);
   });
 });

--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -1,87 +1,62 @@
-import { test, expect } from "@playwright/test";
+import { expect, test } from "@playwright/test";
+
+import { mockCsrfToken } from "./support/mockCsrf";
 
 test.describe("Navigation", () => {
-  test("should load home page successfully", async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
+    await mockCsrfToken(page);
+  });
+
+  test("loads the redesigned home page", async ({ page }) => {
     const response = await page.goto("/");
 
     expect(response?.status()).toBe(200);
-    await expect(page).toHaveTitle(/Alp Talha Yazar/);
+    await expect(page).toHaveTitle(/Senior Backend Engineer/i);
+    await expect(
+      page.getByRole("heading", {
+        name: /I build backend systems that stay reliable under real load\./i,
+      })
+    ).toBeVisible();
   });
 
-  test("should have skip link for accessibility", async ({ page }) => {
+  test("keeps the skip link and core sections", async ({ page }) => {
     await page.goto("/");
 
-    const skipLink = page.locator(".skip-link, a[href='#main-content']");
-    await expect(skipLink).toBeAttached();
-  });
+    await expect(page.locator(".skip-link")).toBeAttached();
 
-  test("should have main sections on page", async ({ page }) => {
-    await page.goto("/");
-
-    // Check for main content sections
-    const sections = [
+    for (const sectionId of [
       "#about",
       "#experience",
       "#skills",
       "#projects",
       "#contact",
-    ];
-
-    for (const sectionId of sections) {
-      const section = page.locator(sectionId);
-      // Section should exist (might be above or below viewport)
-      await expect(section).toBeAttached();
+    ]) {
+      await expect(page.locator(sectionId)).toBeAttached();
     }
   });
 
-  test("should scroll to section when clicking navigation link", async ({
+  test("scrolls to the contact section from header navigation", async ({
     page,
   }) => {
     await page.goto("/");
 
-    // Find a nav link to contact section
-    const contactLink = page.locator('a[href="#contact"], a[href="/#contact"]');
+    await page.locator('header a[href="#contact"]').first().click();
+    await page.waitForTimeout(300);
 
-    if ((await contactLink.count()) > 0) {
-      await contactLink.first().click();
-
-      // Wait for scroll
-      await page.waitForTimeout(500);
-
-      // Contact section should be in view
-      const contactSection = page.locator("#contact");
-      await expect(contactSection).toBeInViewport({ ratio: 0.1 });
-    }
+    await expect(page.locator("#contact")).toBeInViewport({ ratio: 0.1 });
   });
 
-  test("should have proper meta tags for SEO", async ({ page }) => {
+  test("renders canonical and structured data", async ({ page }) => {
     await page.goto("/");
 
-    // Check meta description
-    const metaDescription = page.locator('meta[name="description"]');
-    await expect(metaDescription).toHaveAttribute("content", /.+/);
+    await expect(page.locator('link[rel="canonical"]')).toHaveAttribute(
+      "href",
+      "https://www.alptalha.dev/"
+    );
 
-    // Check Open Graph tags
-    const ogTitle = page.locator('meta[property="og:title"]');
-    await expect(ogTitle).toHaveAttribute("content", /.+/);
-
-    // Check canonical URL
-    const canonical = page.locator('link[rel="canonical"]');
-    await expect(canonical).toHaveAttribute("href", /.+/);
-  });
-
-  test("should load structured data", async ({ page }) => {
-    await page.goto("/");
-
-    // Find JSON-LD script
     const jsonLd = page.locator('script[type="application/ld+json"]');
     await expect(jsonLd).toBeAttached();
-
-    // Parse and validate structure
-    const content = await jsonLd.textContent();
-    expect(content).toBeTruthy();
-
-    const data = JSON.parse(content!);
+    const data = JSON.parse((await jsonLd.textContent()) || "{}");
     expect(data["@context"]).toBe("https://schema.org");
   });
 });

--- a/e2e/support/mockCsrf.ts
+++ b/e2e/support/mockCsrf.ts
@@ -1,0 +1,17 @@
+import type { Page } from "@playwright/test";
+
+export async function mockCsrfToken(page: Page) {
+  await page.route("**/api/csrf-token/", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        success: true,
+        token: "playwright-csrf-token",
+        sessionId: "playwright-session-id",
+        expires: Date.now() + 5 * 60 * 1000,
+        expiresIn: 300,
+      }),
+    });
+  });
+}

--- a/e2e/theme.spec.ts
+++ b/e2e/theme.spec.ts
@@ -1,89 +1,33 @@
-import { test, expect } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 
-test.describe("Theme System", () => {
+import { mockCsrfToken } from "./support/mockCsrf";
+
+test.describe("Redesign shell", () => {
   test.beforeEach(async ({ page }) => {
-    // Clear localStorage before each test
-    await page.goto("/");
-    await page.evaluate(() => localStorage.clear());
-    await page.reload();
+    await mockCsrfToken(page);
   });
 
-  test("should load with light theme by default when no preference", async ({
-    page,
-  }) => {
+  test("does not expose the legacy theme toggle", async ({ page }) => {
     await page.goto("/");
 
-    // Check that either light class is present or dark is not
-    const html = page.locator("html");
-    const classNames = await html.getAttribute("class");
-
-    // Should have light or not have dark (depending on system preference mock)
-    expect(classNames).toBeTruthy();
+    await expect(page.locator(".theme-toggle")).toHaveCount(0);
+    await expect(page.locator("html")).not.toHaveClass(/matrix|starwars/);
   });
 
-  test("should have theme functionality via localStorage", async ({ page }) => {
-    await page.goto("/");
+  test("renders the redesigned 404 page", async ({ page }) => {
+    await page.goto("/missing-route");
 
-    // Verify theme system works by checking we can set and read themes
-    // This tests the underlying functionality regardless of toggle button presence
-    await page.evaluate(() => localStorage.setItem("theme", "dark"));
-    await page.reload();
-    await page.waitForTimeout(500);
-
-    const storedTheme = await page.evaluate(() =>
-      localStorage.getItem("theme")
-    );
-    expect(storedTheme).toBe("dark");
+    await expect(page.getByText("404", { exact: true })).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: /Route not found\./i })
+    ).toBeVisible();
   });
 
-  test("should persist theme in localStorage", async ({ page }) => {
-    await page.goto("/");
+  test("renders the localized 404 page", async ({ page }) => {
+    await page.goto("/tr/olmayan-sayfa");
 
-    // Set theme in localStorage and reload
-    await page.evaluate(() => localStorage.setItem("theme", "dark"));
-    await page.reload();
-
-    // Check localStorage was persisted
-    const storedTheme = await page.evaluate(() =>
-      localStorage.getItem("theme")
-    );
-    expect(storedTheme).toBe("dark");
-  });
-
-  test("form should have anti-spam protection", async ({ page }) => {
-    // Check that form has some protection mechanisms
-    // Either honeypot, CSRF, or validation
-    const form = page.locator("form").first();
-    await expect(form).toBeVisible();
-
-    // Check for hidden fields (honeypot or CSRF)
-    const hiddenInputs = await form.locator('input[type="hidden"]').count();
-    // Form should have some hidden security fields
-    // This is a loose check since implementation may vary
-    expect(hiddenInputs).toBeGreaterThanOrEqual(0);
-  });
-
-  test("should apply matrix theme class", async ({ page }) => {
-    await page.goto("/");
-
-    // Set matrix theme
-    await page.evaluate(() => localStorage.setItem("theme", "matrix"));
-    await page.reload();
-    await page.waitForTimeout(500); // Wait for theme script
-
-    const html = page.locator("html");
-    await expect(html).toHaveClass(/matrix/);
-  });
-
-  test("should apply starwars theme class", async ({ page }) => {
-    await page.goto("/");
-
-    // Set starwars theme
-    await page.evaluate(() => localStorage.setItem("theme", "starwars"));
-    await page.reload();
-    await page.waitForTimeout(500); // Wait for theme script
-
-    const html = page.locator("html");
-    await expect(html).toHaveClass(/starwars/);
+    await expect(
+      page.getByRole("heading", { name: /Rota bulunamadı\./i })
+    ).toBeVisible();
   });
 });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -55,7 +55,7 @@ export default defineConfig({
 
   // Run your local dev server before starting the tests
   webServer: {
-    command: "pnpm dev",
+    command: "npm run dev",
     url: "http://localhost:3000",
     reuseExistingServer: !process.env.CI,
     timeout: 120 * 1000, // 2 minutes to start dev server

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -5,27 +5,11 @@
   "start_url": "/",
   "display": "standalone",
   "background_color": "#000000",
-  "theme_color": "#000000",
+  "theme_color": "#080808",
   "lang": "en",
   "scope": "/",
   "orientation": "portrait-primary",
   "categories": ["business", "productivity", "developer", "portfolio"],
-  "screenshots": [
-    {
-      "src": "/screenshot-wide.png",
-      "sizes": "1280x720",
-      "type": "image/png",
-      "form_factor": "wide",
-      "label": "Portfolio Homepage - Desktop View"
-    },
-    {
-      "src": "/screenshot-mobile.png",
-      "sizes": "390x844",
-      "type": "image/png",
-      "form_factor": "narrow",
-      "label": "Portfolio Homepage - Mobile View"
-    }
-  ],
   "icons": [
     {
       "src": "/favicon.ico",
@@ -33,21 +17,10 @@
       "type": "image/x-icon"
     },
     {
-      "src": "/icon-192.png",
-      "sizes": "192x192",
-      "type": "image/png",
-      "purpose": "maskable any"
-    },
-    {
-      "src": "/icon-512.png",
-      "sizes": "512x512",
-      "type": "image/png",
-      "purpose": "maskable any"
-    },
-    {
-      "src": "/apple-touch-icon.png",
-      "sizes": "180x180",
-      "type": "image/png"
+      "src": "/icon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any"
     }
   ],
   "shortcuts": [
@@ -55,37 +28,19 @@
       "name": "About",
       "short_name": "About",
       "description": "Learn about my background and experience",
-      "url": "/#about",
-      "icons": [
-        {
-          "src": "/icon-192.png",
-          "sizes": "192x192"
-        }
-      ]
+      "url": "/#about"
     },
     {
       "name": "Projects",
       "short_name": "Projects",
       "description": "View my latest projects and work",
-      "url": "/#projects",
-      "icons": [
-        {
-          "src": "/icon-192.png",
-          "sizes": "192x192"
-        }
-      ]
+      "url": "/#projects"
     },
     {
       "name": "Contact",
       "short_name": "Contact",
       "description": "Get in touch for opportunities",
-      "url": "/#contact",
-      "icons": [
-        {
-          "src": "/icon-192.png",
-          "sizes": "192x192"
-        }
-      ]
+      "url": "/#contact"
     }
   ],
   "related_applications": [],

--- a/src/app/[lang]/[...slug]/page.tsx
+++ b/src/app/[lang]/[...slug]/page.tsx
@@ -1,0 +1,22 @@
+import { notFound } from "next/navigation";
+
+import { isSupportedLocale } from "@/lib/i18n/routing";
+
+interface LocaleCatchAllPageProps {
+  params: Promise<{
+    lang: string;
+    slug: string[];
+  }>;
+}
+
+export default async function LocaleCatchAllPage({
+  params,
+}: LocaleCatchAllPageProps) {
+  const { lang } = await params;
+
+  if (!isSupportedLocale(lang) || lang === "en") {
+    notFound();
+  }
+
+  notFound();
+}

--- a/src/app/[lang]/not-found.tsx
+++ b/src/app/[lang]/not-found.tsx
@@ -1,0 +1,14 @@
+import { headers } from "next/headers";
+
+import { NotFoundPage } from "@/components/portfolio";
+import { getPortfolioContent } from "@/lib/content/portfolio";
+import type { PortfolioLocale } from "@/types/portfolio";
+
+export default async function LocaleNotFound() {
+  const headersList = await headers();
+  const localeHeader = headersList.get("x-locale");
+  const locale: PortfolioLocale =
+    localeHeader === "tr" || localeHeader === "es" ? localeHeader : "en";
+
+  return <NotFoundPage content={getPortfolioContent(locale).notFound} locale={locale} />;
+}

--- a/src/app/[lang]/opengraph-image.tsx
+++ b/src/app/[lang]/opengraph-image.tsx
@@ -1,0 +1,24 @@
+import {
+  buildSocialPreviewImage,
+  getSocialPreviewAlt,
+  socialPreviewContentType,
+  socialPreviewSize,
+} from "@/lib/seo/social-preview";
+import type { PortfolioLocale } from "@/types/portfolio";
+
+export const alt = getSocialPreviewAlt("tr");
+export const size = socialPreviewSize;
+export const contentType = socialPreviewContentType;
+
+interface LocaleImageProps {
+  params: Promise<{
+    lang: string;
+  }>;
+}
+
+export default async function LocaleOpenGraphImage({ params }: LocaleImageProps) {
+  const { lang } = await params;
+  const locale: PortfolioLocale = lang === "tr" ? "tr" : "en";
+
+  return buildSocialPreviewImage(locale);
+}

--- a/src/app/[lang]/page.tsx
+++ b/src/app/[lang]/page.tsx
@@ -2,7 +2,7 @@ import { notFound } from "next/navigation";
 
 import { PortfolioPage } from "@/components/portfolio";
 import { getPortfolioContent } from "@/lib/content/portfolio";
-import { isSupportedLocale } from "@/lib/i18n/routing";
+import { isSupportedLocale, publicPortfolioLocales } from "@/lib/i18n/routing";
 import { buildPortfolioMetadata } from "@/lib/seo/portfolio-metadata";
 
 interface LocalePageProps {
@@ -22,7 +22,9 @@ export async function generateMetadata({ params }: LocalePageProps) {
 }
 
 export async function generateStaticParams() {
-  return [{ lang: "tr" }, { lang: "es" }];
+  return publicPortfolioLocales
+    .filter((locale) => locale !== "en")
+    .map((locale) => ({ lang: locale }));
 }
 
 export default async function LocalePage({ params }: LocalePageProps) {

--- a/src/app/[lang]/page.tsx
+++ b/src/app/[lang]/page.tsx
@@ -1,0 +1,36 @@
+import { notFound } from "next/navigation";
+
+import { PortfolioPage } from "@/components/portfolio";
+import { getPortfolioContent } from "@/lib/content/portfolio";
+import { isSupportedLocale } from "@/lib/i18n/routing";
+import { buildPortfolioMetadata } from "@/lib/seo/portfolio-metadata";
+
+interface LocalePageProps {
+  params: Promise<{
+    lang: string;
+  }>;
+}
+
+export async function generateMetadata({ params }: LocalePageProps) {
+  const { lang } = await params;
+
+  if (!isSupportedLocale(lang) || lang === "en") {
+    return buildPortfolioMetadata("en");
+  }
+
+  return buildPortfolioMetadata(lang);
+}
+
+export async function generateStaticParams() {
+  return [{ lang: "tr" }, { lang: "es" }];
+}
+
+export default async function LocalePage({ params }: LocalePageProps) {
+  const { lang } = await params;
+
+  if (!isSupportedLocale(lang) || lang === "en") {
+    notFound();
+  }
+
+  return <PortfolioPage content={getPortfolioContent(lang)} locale={lang} />;
+}

--- a/src/app/[lang]/twitter-image.tsx
+++ b/src/app/[lang]/twitter-image.tsx
@@ -1,0 +1,24 @@
+import {
+  buildSocialPreviewImage,
+  getSocialPreviewAlt,
+  socialPreviewContentType,
+  socialPreviewSize,
+} from "@/lib/seo/social-preview";
+import type { PortfolioLocale } from "@/types/portfolio";
+
+export const alt = getSocialPreviewAlt("tr");
+export const size = socialPreviewSize;
+export const contentType = socialPreviewContentType;
+
+interface LocaleImageProps {
+  params: Promise<{
+    lang: string;
+  }>;
+}
+
+export default async function LocaleTwitterImage({ params }: LocaleImageProps) {
+  const { lang } = await params;
+  const locale: PortfolioLocale = lang === "tr" ? "tr" : "en";
+
+  return buildSocialPreviewImage(locale);
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,274 +1,226 @@
 @import "tailwindcss";
 
-/* Light theme (default) */
 :root {
-  --background: #ffffff;
-  --foreground: #171717;
-  --card: #ffffff;
-  --card-foreground: #171717;
-  --primary: #3b82f6;
-  --primary-foreground: #ffffff;
-  --secondary: #f1f5f9;
-  --secondary-foreground: #0f172a;
-  --muted: #f8fafc;
-  --muted-foreground: #64748b;
-  --accent: #f1f5f9;
-  --accent-foreground: #0f172a;
-  --border: #e2e8f0;
-  --input: #e2e8f0;
-  --ring: #3b82f6;
-  --radius: 0.75rem;
+  --background: #080808;
+  --foreground: #f0ede8;
+  --surface: #111111;
+  --surface-2: #171717;
+  --muted: #9b9b9b;
+  --faint: #4b4b4b;
+  --border: #1e1e1e;
+  --border-strong: #2c2c2c;
+  --accent: #c8ff47;
+  --accent-foreground: #080808;
+  --error: #ff6a6a;
+  --radius: 1.5rem;
 }
 
-/* Dark theme */
-.dark {
-  --background: #0a0a0a;
-  --foreground: #ededed;
-  --card: #0a0a0a;
-  --card-foreground: #ededed;
-  --primary: #3b82f6;
-  --primary-foreground: #ffffff;
-  --secondary: #1e293b;
-  --secondary-foreground: #f8fafc;
-  --muted: #1e293b;
-  --muted-foreground: #94a3b8;
-  --accent: #1e293b;
-  --accent-foreground: #f8fafc;
-  --border: #334155;
-  --input: #334155;
-  --ring: #3b82f6;
-}
-
-/* Ensure light theme is explicit */
-.light {
-  --background: #ffffff;
-  --foreground: #171717;
-  --card: #ffffff;
-  --card-foreground: #171717;
-  --primary: #3b82f6;
-  --primary-foreground: #ffffff;
-  --secondary: #f1f5f9;
-  --secondary-foreground: #0f172a;
-  --muted: #f8fafc;
-  --muted-foreground: #64748b;
-  --accent: #f1f5f9;
-  --accent-foreground: #0f172a;
-  --border: #e2e8f0;
-  --input: #e2e8f0;
-  --ring: #3b82f6;
-}
-
-/* Matrix theme - inspired by The Matrix movie */
-.matrix {
-  --background: #000000;
-  --foreground: #00ff00;
-  --card: #001100;
-  --card-foreground: #00ff00;
-  --primary: #00ff00;
-  --primary-foreground: #000000;
-  --secondary: #003300;
-  --secondary-foreground: #00cc00;
-  --muted: #002200;
-  --muted-foreground: #008800;
-  --accent: #004400;
-  --accent-foreground: #00ff00;
-  --border: #006600;
-  --input: #003300;
-  --ring: #00ff00;
-}
-
-/* Custom theme variables for Tailwind CSS */
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --color-card: var(--card);
-  --color-card-foreground: var(--card-foreground);
-  --color-primary: var(--primary);
-  --color-primary-foreground: var(--primary-foreground);
-  --color-secondary: var(--secondary);
-  --color-secondary-foreground: var(--secondary-foreground);
-  --color-muted: var(--muted);
-  --color-muted-foreground: var(--muted-foreground);
+  --color-surface: var(--surface);
+  --color-surface-2: var(--surface-2);
+  --color-muted-foreground: var(--muted);
+  --color-faint: var(--faint);
+  --color-border: var(--border);
+  --color-border-strong: var(--border-strong);
   --color-accent: var(--accent);
   --color-accent-foreground: var(--accent-foreground);
-  --color-border: var(--border);
-  --color-input: var(--input);
-  --color-ring: var(--ring);
+  --color-error: var(--error);
 }
 
-body {
-  background: var(--background);
-  color: var(--foreground);
-  font-family: var(--font-sans), Arial, Helvetica, sans-serif;
+* {
+  box-sizing: border-box;
 }
 
 html {
-  scroll-behavior: smooth;
+  background: var(--background);
+  color: var(--foreground);
 }
 
-.gradient-text {
-  background: linear-gradient(135deg, #3b82f6 0%, #8b5cf6 50%, #1d4ed8 100%);
-  background-clip: text;
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
+body {
+  min-height: 100vh;
+  background:
+    radial-gradient(circle at top, rgba(200, 255, 71, 0.06), transparent 35%),
+    var(--background);
+  color: var(--foreground);
+  font-family: var(--font-space-grotesk), system-ui, sans-serif;
 }
 
-/* Matrix theme gradient text */
-.matrix .gradient-text {
-  background: linear-gradient(135deg, #00ff00 0%, #00cc00 50%, #008800 100%);
-  background-clip: text;
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
+a,
+button,
+input,
+textarea {
+  transition:
+    color 160ms ease,
+    background-color 160ms ease,
+    border-color 160ms ease,
+    opacity 160ms ease,
+    transform 160ms ease;
 }
 
-/* Star Wars theme - A long time ago in a galaxy far, far away... */
-.starwars {
-  --background: #000000;
-  --foreground: #ffffff;
-  --card: #0a0a0f;
-  --card-foreground: #ffffff;
-  --primary: #4fc3f7;
-  --primary-foreground: #000000;
-  --secondary: #263238;
-  --secondary-foreground: #ffffff;
-  --muted: #37474f;
-  --muted-foreground: #b0bec5;
-  --accent: #00bcd4;
-  --accent-foreground: #000000;
-  --border: #455a64;
-  --input: #37474f;
-  --ring: #4fc3f7;
-
-  /* Star Wars specific colors */
-  --lightsaber-blue: #4fc3f7;
-  --lightsaber-green: #66bb6a;
-  --lightsaber-red: #f44336;
-  --lightsaber-purple: #9c27b0;
-  --empire-gray: #263238;
-  --hologram-blue: #00bcd4;
-  --golden-amber: #ffc107;
-  --death-star-gray: #455a64;
+button,
+input,
+textarea {
+  font: inherit;
 }
 
-/* Matrix theme specific styles */
-.matrix {
-  /* Add subtle glow effect to text in matrix mode */
+::selection {
+  background: rgba(200, 255, 71, 0.24);
+  color: var(--foreground);
 }
 
-.matrix h1,
-.matrix h2,
-.matrix h3 {
-  text-shadow: 0 0 10px rgba(0, 255, 0, 0.3);
+::placeholder {
+  color: var(--muted);
 }
 
-.matrix .bg-primary {
-  background-color: #00ff00 !important;
-  box-shadow: 0 0 20px rgba(0, 255, 0, 0.3);
+.skip-link {
+  position: absolute;
+  left: 1rem;
+  top: -100px;
+  z-index: 100;
+  border-radius: 999px;
+  background: var(--accent);
+  color: var(--accent-foreground);
+  padding: 0.75rem 1rem;
 }
 
-.matrix .border-primary {
-  border-color: #00ff00 !important;
-  box-shadow: 0 0 10px rgba(0, 255, 0, 0.2);
+.skip-link:focus {
+  top: 1rem;
 }
 
-/* Star Wars theme specific styles */
-.starwars {
-  background: radial-gradient(ellipse at center, #001122 0%, #000000 70%);
-  color: #ffffff;
+.section-shell {
+  padding: 7rem 1.25rem;
 }
 
-.starwars h1,
-.starwars h2,
-.starwars h3 {
-  text-shadow: 0 0 10px rgba(79, 195, 247, 0.3);
+.shell-grid {
+  background-image: radial-gradient(circle, rgba(255, 255, 255, 0.08) 1px, transparent 1px);
+  background-size: 28px 28px;
 }
 
-.starwars .bg-primary {
-  background-color: var(--lightsaber-blue) !important;
-  box-shadow: 0 0 20px rgba(79, 195, 247, 0.4), 0 0 40px rgba(79, 195, 247, 0.2);
-  border: 1px solid rgba(79, 195, 247, 0.6);
+.surface-card {
+  border: 1px solid var(--border);
+  background: var(--surface-2);
+  border-radius: calc(var(--radius) + 0.5rem);
+  padding: 2rem;
 }
 
-.starwars .border-primary {
-  border-color: var(--lightsaber-blue) !important;
-  box-shadow: 0 0 10px rgba(79, 195, 247, 0.3);
+.surface-card:hover {
+  border-color: var(--border-strong);
 }
 
-/* Lightsaber glow effects */
-.starwars .lightsaber-glow {
-  box-shadow: 0 0 5px currentColor, 0 0 10px currentColor, 0 0 15px currentColor,
-    0 0 20px currentColor;
+.section-divider {
+  height: 1px;
+  width: 100%;
+  background: var(--border);
 }
 
-.starwars .hologram-effect {
-  position: relative;
-  background: linear-gradient(
-    45deg,
-    transparent 30%,
-    rgba(0, 188, 212, 0.1) 50%,
-    transparent 70%
-  );
-  border: 1px solid rgba(0, 188, 212, 0.3);
-  box-shadow: inset 0 0 20px rgba(0, 188, 212, 0.1),
-    0 0 20px rgba(0, 188, 212, 0.1);
+.mono-label {
+  font-family: var(--font-jetbrains-mono), monospace;
+  font-size: 0.72rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
 }
 
-.starwars .space-background {
-  background: radial-gradient(2px 2px at 20px 30px, #ffffff, transparent),
-    radial-gradient(2px 2px at 40px 70px, rgba(255, 255, 255, 0.8), transparent),
-    radial-gradient(1px 1px at 90px 40px, #ffffff, transparent),
-    radial-gradient(
-      1px 1px at 130px 80px,
-      rgba(255, 255, 255, 0.6),
-      transparent
-    ),
-    radial-gradient(2px 2px at 160px 30px, #ffffff, transparent),
-    linear-gradient(135deg, #001122 0%, #000000 50%, #000011 100%);
-  background-size: 200px 100px;
-  animation: starfield 20s linear infinite;
+.accent-chip {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: rgba(255, 255, 255, 0.02);
+  padding: 0.35rem 0.7rem;
+  font-family: var(--font-jetbrains-mono), monospace;
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  color: var(--muted);
 }
 
-@keyframes starfield {
-  from {
-    background-position: 0 0;
+.theme-chip {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  border: 1px solid rgba(200, 255, 71, 0.25);
+  background: rgba(200, 255, 71, 0.09);
+  padding: 0.35rem 0.7rem;
+  font-family: var(--font-jetbrains-mono), monospace;
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  color: var(--accent);
+}
+
+.primary-button,
+.secondary-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  border-radius: 999px;
+  padding: 0.95rem 1.4rem;
+  font-family: var(--font-jetbrains-mono), monospace;
+  font-size: 0.74rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.primary-button {
+  background: var(--accent);
+  color: var(--accent-foreground);
+}
+
+.primary-button:hover {
+  transform: translateY(-1px);
+}
+
+.secondary-button {
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--foreground);
+}
+
+.secondary-button:hover {
+  border-color: var(--border-strong);
+  background: var(--surface);
+}
+
+.input-shell {
+  width: 100%;
+  border-radius: 1.25rem;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--foreground);
+  padding: 0.95rem 1rem;
+  line-height: 1.6;
+}
+
+.input-shell:focus {
+  outline: none;
+  border-color: rgba(200, 255, 71, 0.55);
+  box-shadow: 0 0 0 3px rgba(200, 255, 71, 0.12);
+}
+
+.input-shell[aria-invalid="true"] {
+  border-color: rgba(255, 106, 106, 0.55);
+  box-shadow: 0 0 0 3px rgba(255, 106, 106, 0.12);
+}
+
+.writing-vertical {
+  writing-mode: vertical-rl;
+}
+
+:focus-visible {
+  outline: 2px solid rgba(200, 255, 71, 0.55);
+  outline-offset: 2px;
+}
+
+@media (max-width: 640px) {
+  .section-shell {
+    padding: 5.5rem 1.25rem;
   }
-  to {
-    background-position: -200px -100px;
+
+  .surface-card {
+    padding: 1.5rem;
   }
 }
 
-/* Star Wars gradient text */
-.starwars .gradient-text {
-  background: linear-gradient(
-    135deg,
-    #4fc3f7 0%,
-    #66bb6a 25%,
-    #ffc107 50%,
-    #f44336 75%,
-    #9c27b0 100%
-  );
-  background-clip: text;
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-size: 200% 200%;
-  animation: rainbow-lightsaber 3s ease-in-out infinite;
-}
-
-@keyframes rainbow-lightsaber {
-  0%,
-  100% {
-    background-position: 0% 50%;
-  }
-  50% {
-    background-position: 100% 50%;
-  }
-}
-
-/* =================================================
-   ACCESSIBILITY IMPROVEMENTS
-   ================================================= */
-
-/* Respect user's motion preferences */
 @media (prefers-reduced-motion: reduce) {
   *,
   *::before,
@@ -277,107 +229,5 @@ html {
     animation-iteration-count: 1 !important;
     transition-duration: 0.01ms !important;
     scroll-behavior: auto !important;
-  }
-
-  /* Disable canvas animations */
-  canvas {
-    display: none !important;
-  }
-
-  /* Disable complex transforms and animations */
-  .animate-spin,
-  .animate-ping,
-  .animate-pulse,
-  .animate-bounce {
-    animation: none !important;
-  }
-
-  /* Disable matrix and starwars background animations */
-  .space-background {
-    animation: none !important;
-  }
-
-  .rainbow-lightsaber {
-    animation: none !important;
-  }
-
-  /* Disable motion in framer-motion components */
-  [data-framer-component] {
-    transform: none !important;
-    transition: none !important;
-  }
-}
-
-/* Enhanced focus styles for better accessibility */
-:focus-visible {
-  outline: 2px solid var(--ring);
-  outline-offset: 2px;
-  border-radius: 4px;
-}
-
-/* Ensure good contrast for focus indicators */
-button:focus-visible,
-a:focus-visible,
-input:focus-visible,
-select:focus-visible,
-textarea:focus-visible {
-  outline: 2px solid var(--ring);
-  outline-offset: 2px;
-}
-
-/* Skip link for screen readers */
-.skip-link {
-  position: absolute;
-  top: -40px;
-  left: 6px;
-  background: var(--primary);
-  color: var(--primary-foreground);
-  padding: 8px;
-  text-decoration: none;
-  border-radius: 4px;
-  z-index: 100;
-  font-weight: 600;
-}
-
-.skip-link:focus {
-  top: 6px;
-}
-
-/* High contrast focus for theme toggle */
-.theme-toggle:focus-visible {
-  outline: 3px solid var(--ring);
-  outline-offset: 2px;
-  box-shadow: 0 0 0 1px var(--background);
-}
-
-/* Screen reader only text */
-.sr-only {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border: 0;
-}
-
-/* Enhanced keyboard navigation styles */
-.keyboard-focus:focus-visible {
-  outline: 2px solid var(--ring);
-  outline-offset: 2px;
-  box-shadow: 0 0 0 4px rgba(var(--ring), 0.1);
-}
-
-/* Ensure minimum touch target size for mobile */
-@media (hover: none) and (pointer: coarse) {
-  button,
-  a,
-  input,
-  select,
-  textarea {
-    min-height: 44px;
-    min-width: 44px;
   }
 }

--- a/src/app/icon.svg
+++ b/src/app/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256">
+  <rect width="256" height="256" rx="48" fill="#080808" />
+  <path d="M52 64h58l32 80 32-80h30l-54 128h-22L104 64v128H52z" fill="#d8ff48" />
+</svg>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,194 +1,25 @@
 import type { Metadata } from "next";
 import { headers } from "next/headers";
-import { Geist, Geist_Mono } from "next/font/google";
-import { StructuredData } from "@/components/utils";
-import { ThemeProvider } from "@/components/theme";
+import { JetBrains_Mono, Space_Grotesk } from "next/font/google";
 import { GoogleAnalytics } from "@next/third-parties/google";
-import { I18nProvider } from "@/lib/i18n";
-import { themeScript } from "@/lib/theme-script";
+
+import StructuredData from "@/components/utils/StructuredData";
+import type { PortfolioLocale } from "@/types/portfolio";
+
 import "./globals.css";
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
+const spaceGrotesk = Space_Grotesk({
+  variable: "--font-space-grotesk",
   subsets: ["latin"],
 });
 
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
+const jetBrainsMono = JetBrains_Mono({
+  variable: "--font-jetbrains-mono",
   subsets: ["latin"],
 });
 
 export const metadata: Metadata = {
-  title: {
-    default: "Alp Talha Yazar - Senior Backend Developer & Software Engineer",
-    template: "%s | Alp Talha Yazar - Backend Developer",
-  },
-  description:
-    "Senior Backend Developer with 5+ years experience in .NET, C#, microservices, and enterprise applications. Specializing in scalable B2B/B2G solutions, PostgreSQL databases, and cloud technologies. Available for remote opportunities.",
-  keywords: [
-    // Primary keywords
-    "Backend Developer",
-    "Senior Backend Developer",
-    ".NET Developer",
-    "C# Developer",
-    "Software Engineer",
-
-    // Technical skills
-    ".NET",
-    "C#",
-    "ASP.NET Core",
-    "Entity Framework",
-    "Microservices",
-    "PostgreSQL",
-    "SQL Server",
-    "RESTful APIs",
-    "Web APIs",
-
-    // Frontend skills
-    "React",
-    "TypeScript",
-    "JavaScript",
-    "Next.js",
-    "Full Stack Developer",
-
-    // Cloud & DevOps
-    "Azure",
-    "AWS",
-    "Docker",
-    "Kubernetes",
-    "CI/CD",
-
-    // Architecture & Patterns
-    "Enterprise Applications",
-    "System Architecture",
-    "Domain Driven Design",
-    "SOLID Principles",
-    "Clean Architecture",
-
-    // Business domains
-    "B2B Applications",
-    "B2G Applications",
-    "E-commerce",
-    "Financial Software",
-
-    // Location & availability
-    "Turkey Developer",
-    "Remote Developer",
-    "Freelance Developer",
-    "Software Consultant",
-  ],
-  authors: [{ name: "Alp Talha Yazar", url: "https://www.alptalha.dev" }],
-  creator: "Alp Talha Yazar",
-  publisher: "Alp Talha Yazar",
-  category: "Technology",
-  classification: "Software Development Portfolio",
   metadataBase: new URL("https://www.alptalha.dev"),
-
-  alternates: {
-    canonical: "https://www.alptalha.dev/",
-    languages: {
-      "en-US": "https://www.alptalha.dev/",
-      "tr-TR": "https://www.alptalha.dev/tr",
-      "es-ES": "https://www.alptalha.dev/es",
-    },
-  },
-
-  openGraph: {
-    title: "Alp Talha Yazar - Senior Backend Developer & Software Engineer",
-    description:
-      "Senior Backend Developer with 5+ years experience in .NET, C#, microservices, and enterprise applications. Expert in scalable B2B/B2G solutions and modern cloud technologies.",
-    type: "profile",
-    locale: "en_US",
-    alternateLocale: ["tr_TR", "es_ES"],
-    url: "https://www.alptalha.dev",
-    siteName: "Alp Talha Yazar - Portfolio & Resume",
-    images: [
-      {
-        url: "https://www.alptalha.dev/og-image.jpg",
-        width: 1200,
-        height: 630,
-        alt: "Alp Talha Yazar - Senior Backend Developer Portfolio",
-        type: "image/jpeg",
-      },
-      {
-        url: "https://www.alptalha.dev/og-image-square.jpg",
-        width: 1200,
-        height: 1200,
-        alt: "Alp Talha Yazar - Backend Developer",
-        type: "image/jpeg",
-      },
-    ],
-  },
-
-  twitter: {
-    card: "summary_large_image",
-    title: "Alp Talha Yazar - Senior Backend Developer & Software Engineer",
-    description:
-      "Senior Backend Developer specializing in .NET, C#, microservices, and enterprise applications. 5+ years experience in scalable B2B/B2G solutions.",
-    creator: "@alptalha_dev",
-    site: "@alptalha_dev",
-    images: {
-      url: "https://www.alptalha.dev/twitter-card.jpg",
-      alt: "Alp Talha Yazar - Senior Backend Developer Portfolio",
-      width: 1200,
-      height: 630,
-    },
-  },
-
-  robots: {
-    index: true,
-    follow: true,
-    nocache: false,
-    googleBot: {
-      index: true,
-      follow: true,
-      noimageindex: false,
-      "max-video-preview": -1,
-      "max-image-preview": "large",
-      "max-snippet": -1,
-    },
-  },
-
-  verification: {
-    google:
-      process.env.NEXT_PUBLIC_GOOGLE_VERIFICATION ||
-      "your-google-verification-code",
-    yandex: process.env.NEXT_PUBLIC_YANDEX_VERIFICATION,
-  },
-
-  other: {
-    // Technical SEO meta tags
-    "theme-color": "#000000",
-    "color-scheme": "dark light",
-    "mobile-web-app-capable": "yes",
-    "apple-mobile-web-app-capable": "yes",
-    "apple-mobile-web-app-status-bar-style": "default",
-    "apple-mobile-web-app-title": "Alp Talha Yazar",
-    "application-name": "Alp Talha Yazar Portfolio",
-    "msapplication-TileColor": "#000000",
-    "msapplication-config": "/browserconfig.xml",
-
-    // Geographic & Language targeting
-    "geo.region": "TR",
-    "geo.placename": "Turkey",
-    language: "en",
-    "content-language": "en-US",
-
-    // Professional tags
-    "profile:first_name": "Alp Talha",
-    "profile:last_name": "Yazar",
-    "profile:gender": "male",
-
-    // Business information
-    "business:contact_data:locality": "Turkey",
-    "business:contact_data:region": "TR",
-    "business:contact_data:country_name": "Turkey",
-
-    // Rating and review structured data hints
-    rating: "5",
-    ratingCount: "127",
-    priceRange: "$$$",
-  },
 };
 
 export default async function RootLayout({
@@ -196,80 +27,33 @@ export default async function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  // Get nonce from middleware for CSP
   const headersList = await headers();
-  const nonce = headersList.get("x-nonce") || "";
+  const localeHeader = headersList.get("x-locale");
+  const requestLocale: PortfolioLocale =
+    localeHeader === "tr" || localeHeader === "es" ? localeHeader : "en";
 
   return (
-    <html lang="en" className="scroll-smooth" suppressHydrationWarning>
+    <html lang={requestLocale} className="scroll-smooth" suppressHydrationWarning>
       <head>
-        <StructuredData />
-        <script nonce={nonce} dangerouslySetInnerHTML={{ __html: themeScript }} />
-
-        {/* Additional SEO Meta Tags */}
+        <StructuredData locale={requestLocale} />
         <meta name="format-detection" content="telephone=no" />
-        <meta name="mobile-web-app-capable" content="yes" />
-        <meta name="apple-mobile-web-app-capable" content="yes" />
-        <meta
-          name="apple-mobile-web-app-status-bar-style"
-          content="black-translucent"
-        />
-        <meta name="apple-mobile-web-app-title" content="Alp Talha Yazar" />
-
-        {/* Favicon and App Icons */}
+        <meta name="theme-color" content="#080808" />
         <link rel="icon" href="/favicon.ico" sizes="any" />
         <link rel="icon" type="image/svg+xml" href="/icon.svg" />
         <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
         <link rel="manifest" href="/manifest.json" />
-
-        {/* Preconnect for performance */}
-        <link rel="preconnect" href="https://fonts.googleapis.com" />
-        <link
-          rel="preconnect"
-          href="https://fonts.gstatic.com"
-          crossOrigin=""
-        />
-        <link rel="preconnect" href="https://www.google-analytics.com" />
-        <link rel="preconnect" href="https://analytics.google.com" />
-
-        {/* DNS Prefetch for external resources */}
-        <link rel="dns-prefetch" href="//github.com" />
-        <link rel="dns-prefetch" href="//linkedin.com" />
-        <link rel="dns-prefetch" href="//twitter.com" />
-
-        {/* Alternate language versions */}
-        <link rel="alternate" hrefLang="en" href="https://www.alptalha.dev/" />
-        <link
-          rel="alternate"
-          hrefLang="tr"
-          href="https://www.alptalha.dev/tr"
-        />
-        <link
-          rel="alternate"
-          hrefLang="es"
-          href="https://www.alptalha.dev/es"
-        />
-        <link
-          rel="alternate"
-          hrefLang="x-default"
-          href="https://www.alptalha.dev/"
-        />
       </head>
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        className={`${spaceGrotesk.variable} ${jetBrainsMono.variable} bg-background text-foreground antialiased`}
       >
-        {/* Skip link for keyboard navigation */}
         <a href="#main-content" className="skip-link">
           Skip to main content
         </a>
-
-        <I18nProvider>
-          <ThemeProvider>{children}</ThemeProvider>
-        </I18nProvider>
+        {children}
       </body>
-      {process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID && (
+      {process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID ? (
         <GoogleAnalytics gaId={process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID} />
-      )}
+      ) : null}
     </html>
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -40,7 +40,7 @@ export default async function RootLayout({
         <meta name="theme-color" content="#080808" />
         <link rel="icon" href="/favicon.ico" sizes="any" />
         <link rel="icon" type="image/svg+xml" href="/icon.svg" />
-        <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
+        <link rel="apple-touch-icon" href="/favicon.ico" />
         <link rel="manifest" href="/manifest.json" />
       </head>
       <body

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,49 +1,8 @@
-"use client";
-
-import Link from "next/link";
-import { motion } from "framer-motion";
-import { Home, ArrowLeft } from "lucide-react";
+import { NotFoundPage } from "@/components/portfolio";
+import { getPortfolioContent } from "@/lib/content/portfolio";
 
 export default function NotFound() {
-  return (
-    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-background via-background to-muted/30">
-      <div className="max-w-md mx-auto text-center px-4">
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.8 }}
-        >
-          <div className="mb-8">
-            <h1 className="text-6xl md:text-8xl font-bold gradient-text mb-4">
-              404
-            </h1>
-            <h2 className="text-2xl md:text-3xl font-semibold text-foreground mb-4">
-              Page Not Found
-            </h2>
-            <p className="text-muted-foreground leading-relaxed">
-              Sorry, the page you're looking for doesn't exist. It might have
-              been moved, deleted, or you entered the wrong URL.
-            </p>
-          </div>
+  const content = getPortfolioContent("en");
 
-          <div className="flex flex-col sm:flex-row gap-4 justify-center">
-            <Link
-              href="/"
-              className="inline-flex items-center justify-center gap-2 px-6 py-3 rounded-lg bg-primary text-primary-foreground font-semibold hover:bg-primary/90 transition-colors duration-200"
-            >
-              <Home size={18} />
-              Go Home
-            </Link>
-            <button
-              onClick={() => window.history.back()}
-              className="inline-flex items-center justify-center gap-2 px-6 py-3 rounded-lg border border-border bg-background hover:bg-secondary transition-colors duration-200"
-            >
-              <ArrowLeft size={18} />
-              Go Back
-            </button>
-          </div>
-        </motion.div>
-      </div>
-    </div>
-  );
+  return <NotFoundPage content={content.notFound} locale="en" />;
 }

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -1,0 +1,14 @@
+import {
+  buildSocialPreviewImage,
+  getSocialPreviewAlt,
+  socialPreviewContentType,
+  socialPreviewSize,
+} from "@/lib/seo/social-preview";
+
+export const alt = getSocialPreviewAlt("en");
+export const size = socialPreviewSize;
+export const contentType = socialPreviewContentType;
+
+export default function OpenGraphImage() {
+  return buildSocialPreviewImage("en");
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,73 +1,9 @@
-import { Header, Footer, ScrollToTop } from "@/components/layout";
-import {
-  Hero,
-  About,
-  Experience,
-  Skills,
-  Projects,
-  Contact,
-} from "@/components/pages";
-import { SectionErrorBoundary, ThemeErrorBoundary } from "@/components/utils";
-import { lazy, Suspense } from "react";
+import { PortfolioPage } from "@/components/portfolio";
+import { getPortfolioContent } from "@/lib/content/portfolio";
+import { buildPortfolioMetadata } from "@/lib/seo/portfolio-metadata";
 
-// Lazy load heavy theme components
-const MatrixRain = lazy(() => import("@/components/theme/MatrixRain"));
-const StarField = lazy(() => import("@/components/theme/StarField"));
+export const metadata = buildPortfolioMetadata("en");
 
-export default function Home() {
-  return (
-    <div className="min-h-screen relative">
-      {/* Lazy-loaded theme components with error boundaries */}
-      <ThemeErrorBoundary componentName="MatrixRain">
-        <Suspense fallback={null}>
-          <MatrixRain />
-        </Suspense>
-      </ThemeErrorBoundary>
-      <ThemeErrorBoundary componentName="StarField">
-        <Suspense fallback={null}>
-          <StarField />
-        </Suspense>
-      </ThemeErrorBoundary>
-
-      <div className="relative z-10">
-        <SectionErrorBoundary sectionName="Header">
-          <Header />
-        </SectionErrorBoundary>
-
-        <main id="main-content" tabIndex={-1}>
-          <SectionErrorBoundary sectionName="Hero">
-            <Hero />
-          </SectionErrorBoundary>
-
-          <SectionErrorBoundary sectionName="About">
-            <About />
-          </SectionErrorBoundary>
-
-          <SectionErrorBoundary sectionName="Experience">
-            <Experience />
-          </SectionErrorBoundary>
-
-          <SectionErrorBoundary sectionName="Skills">
-            <Skills />
-          </SectionErrorBoundary>
-
-          <SectionErrorBoundary sectionName="Projects">
-            <Projects />
-          </SectionErrorBoundary>
-
-          <SectionErrorBoundary sectionName="Contact">
-            <Contact />
-          </SectionErrorBoundary>
-        </main>
-
-        <SectionErrorBoundary sectionName="Footer">
-          <Footer />
-        </SectionErrorBoundary>
-
-        <SectionErrorBoundary sectionName="ScrollToTop">
-          <ScrollToTop />
-        </SectionErrorBoundary>
-      </div>
-    </div>
-  );
+export default function HomePage() {
+  return <PortfolioPage content={getPortfolioContent("en")} locale="en" />;
 }

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,15 +1,16 @@
 import { MetadataRoute } from "next";
 
+import { siteConfig } from "@/lib/site";
+
 export const dynamic = "force-static";
 
 export default function robots(): MetadataRoute.Robots {
-  const baseUrl = "https://www.alptalha.dev";
-
   return {
     rules: {
       userAgent: "*",
       allow: "/",
     },
-    sitemap: `${baseUrl}/sitemap.xml`,
+    sitemap: `${siteConfig.baseUrl}/sitemap.xml`,
+    host: siteConfig.baseUrl,
   };
 }

--- a/src/app/sitemap.test.ts
+++ b/src/app/sitemap.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+
+import sitemap from "./sitemap";
+
+describe("sitemap", () => {
+  it("uses trailing slashes that match canonical portfolio routes", () => {
+    expect(sitemap()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          url: "https://www.alptalha.dev/",
+        }),
+        expect.objectContaining({
+          url: "https://www.alptalha.dev/tr/",
+        }),
+      ])
+    );
+  });
+});

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,47 +1,31 @@
 import { MetadataRoute } from "next";
 
+import { siteConfig } from "@/lib/site";
+
 export const dynamic = "force-static";
 export const revalidate = false;
 
 export default function sitemap(): MetadataRoute.Sitemap {
-  const baseUrl = "https://www.alptalha.dev";
+  const lastModified = new Date();
 
   return [
     {
-      url: baseUrl,
-      lastModified: new Date(),
+      url: `${siteConfig.baseUrl}/`,
+      lastModified,
       changeFrequency: "weekly",
       priority: 1,
     },
     {
-      url: `${baseUrl}/#about`,
-      lastModified: new Date(),
-      changeFrequency: "monthly",
-      priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/#experience`,
-      lastModified: new Date(),
-      changeFrequency: "monthly",
-      priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/#skills`,
-      lastModified: new Date(),
-      changeFrequency: "monthly",
-      priority: 0.7,
-    },
-    {
-      url: `${baseUrl}/#projects`,
-      lastModified: new Date(),
-      changeFrequency: "monthly",
+      url: `${siteConfig.baseUrl}/tr`,
+      lastModified,
+      changeFrequency: "weekly",
       priority: 0.9,
     },
     {
-      url: `${baseUrl}/#contact`,
-      lastModified: new Date(),
-      changeFrequency: "monthly",
-      priority: 0.6,
+      url: `${siteConfig.baseUrl}/es`,
+      lastModified,
+      changeFrequency: "weekly",
+      priority: 0.9,
     },
   ];
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -21,11 +21,5 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: "weekly",
       priority: 0.9,
     },
-    {
-      url: `${siteConfig.baseUrl}/es`,
-      lastModified,
-      changeFrequency: "weekly",
-      priority: 0.9,
-    },
   ];
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -16,7 +16,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 1,
     },
     {
-      url: `${siteConfig.baseUrl}/tr`,
+      url: `${siteConfig.baseUrl}/tr/`,
       lastModified,
       changeFrequency: "weekly",
       priority: 0.9,

--- a/src/app/twitter-image.tsx
+++ b/src/app/twitter-image.tsx
@@ -1,0 +1,14 @@
+import {
+  buildSocialPreviewImage,
+  getSocialPreviewAlt,
+  socialPreviewContentType,
+  socialPreviewSize,
+} from "@/lib/seo/social-preview";
+
+export const alt = getSocialPreviewAlt("en");
+export const size = socialPreviewSize;
+export const contentType = socialPreviewContentType;
+
+export default function TwitterImage() {
+  return buildSocialPreviewImage("en");
+}

--- a/src/components/pages/ContactForm.tsx
+++ b/src/components/pages/ContactForm.tsx
@@ -18,7 +18,7 @@ import {
 interface ContactFormProps {
   security: UseCSRFSecurityReturn;
   submission: UseContactSubmissionReturn;
-  onSubmit: (data: ContactFormData) => Promise<void>;
+  onSubmit: (data: ContactFormData) => Promise<boolean>;
   className?: string;
 }
 
@@ -63,8 +63,8 @@ const ContactForm: React.FC<ContactFormProps> = ({
 
   // Handle form submission with reset
   const handleFormSubmit = async (data: ContactFormData) => {
-    await onSubmit(data);
-    if (!submission.submitError) {
+    const wasSuccessful = await onSubmit(data);
+    if (wasSuccessful) {
       reset();
     }
   };

--- a/src/components/portfolio/About.tsx
+++ b/src/components/portfolio/About.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { motion } from "framer-motion";
+
+import { socialLinks } from "@/lib/site";
+import type { PortfolioAboutContent } from "@/types/portfolio";
+
+import { SectionLabel } from "./SectionLabel";
+
+interface AboutProps {
+  content: PortfolioAboutContent;
+}
+
+export function About({ content }: AboutProps) {
+  return (
+    <section id="about" className="section-shell border-t border-border">
+      <div className="mx-auto max-w-6xl">
+        <SectionLabel
+          number={content.sectionNumber}
+          title={content.sectionTitle}
+        />
+
+        <div className="grid gap-16 lg:grid-cols-[1.1fr_1fr]">
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true, margin: "-80px" }}
+            className="space-y-10"
+          >
+            <h2 className="max-w-xl text-4xl font-semibold tracking-[-0.04em] text-foreground sm:text-5xl">
+              {content.lead}
+            </h2>
+            <div className="h-0.5 w-10 bg-accent" />
+            <div className="flex flex-wrap gap-3">
+              {socialLinks.map((link) => (
+                <a
+                  key={link.label}
+                  href={link.href}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="secondary-button"
+                >
+                  {link.label}
+                </a>
+              ))}
+            </div>
+          </motion.div>
+
+          <motion.div
+            initial={{ opacity: 0, y: 24 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true, margin: "-80px" }}
+            transition={{ delay: 0.1 }}
+            className="space-y-6"
+          >
+            {content.paragraphs.map((paragraph) => (
+              <p key={paragraph} className="text-lg leading-8 text-muted-foreground">
+                {paragraph}
+              </p>
+            ))}
+
+            <div className="inline-flex items-center gap-3 rounded-full border border-border bg-surface px-5 py-3">
+              <span className="h-2 w-2 rounded-full bg-accent" />
+              <span className="mono-label text-foreground">{content.statusPill}</span>
+            </div>
+          </motion.div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/portfolio/Capabilities.tsx
+++ b/src/components/portfolio/Capabilities.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { motion } from "framer-motion";
+
+import type { PortfolioContent } from "@/types/portfolio";
+
+import { SectionLabel } from "./SectionLabel";
+
+interface CapabilitiesProps {
+  content: PortfolioContent["capabilities"];
+}
+
+export function Capabilities({ content }: CapabilitiesProps) {
+  return (
+    <section id="skills" className="section-shell border-t border-border bg-surface">
+      <div className="mx-auto max-w-6xl">
+        <SectionLabel
+          number={content.sectionNumber}
+          title={content.sectionTitle}
+        />
+
+        <div className="grid gap-3 md:grid-cols-2">
+          {content.groups.map((group, index) => (
+            <motion.article
+              key={group.category}
+              initial={{ opacity: 0, y: 22 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true, margin: "-60px" }}
+              transition={{ delay: index * 0.06 }}
+              className="surface-card"
+            >
+              <div className="mb-6 flex items-center gap-3 border-b border-border pb-5">
+                <span className="h-1.5 w-1.5 rounded-full bg-accent" />
+                <span className="mono-label text-accent">{group.category}</span>
+              </div>
+
+              <div className="space-y-3">
+                {group.items.map((item) => (
+                  <div key={item} className="flex items-start gap-3">
+                    <span className="mt-2 h-1 w-1 rounded-full bg-faint" />
+                    <span className="text-base leading-7 text-muted-foreground">
+                      {item}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </motion.article>
+          ))}
+        </div>
+
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true, margin: "-60px" }}
+          className="mt-3 flex flex-wrap items-center justify-between gap-5 rounded-[28px] border border-accent/25 bg-accent/10 px-8 py-7"
+        >
+          <p className="max-w-3xl text-base leading-8 text-foreground">
+            {content.callout}
+          </p>
+          <span className="mono-label text-accent">{content.statLabel}</span>
+        </motion.div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/portfolio/ContactForm.test.tsx
+++ b/src/components/portfolio/ContactForm.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getPortfolioContent } from "@/lib/content/portfolio";
+import type {
+  UseContactSubmissionReturn,
+} from "@/hooks/useContactSubmission";
+import type { UseCSRFSecurityReturn } from "@/hooks/useCSRFSecurity";
+
+import { ContactForm } from "./ContactForm";
+
+const mockSecurity: UseCSRFSecurityReturn = {
+  csrfToken: "csrf-token",
+  sessionId: "session-id",
+  tokenExpires: Date.now() + 60_000,
+  isSecurityLoading: false,
+  securityError: null,
+  fetchCSRFToken: vi.fn(async () => true),
+  clearSecurityError: vi.fn(),
+  isTokenExpired: vi.fn(() => false),
+  isTokenValid: vi.fn(() => true),
+};
+
+const mockSubmission: UseContactSubmissionReturn = {
+  isSubmitted: false,
+  submitError: null,
+  isBlocked: false,
+  blockInfo: null,
+  onSubmit: vi.fn(async () => true),
+  clearSubmitError: vi.fn(),
+  resetSubmissionState: vi.fn(),
+};
+
+vi.mock("@/hooks", () => ({
+  useCSRFSecurity: () => mockSecurity,
+  useContactSubmission: () => mockSubmission,
+}));
+
+describe("ContactForm", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSubmission.isSubmitted = false;
+    mockSubmission.submitError = null;
+    mockSubmission.isBlocked = false;
+    mockSubmission.blockInfo = null;
+    mockSubmission.onSubmit = vi.fn(async () => true);
+  });
+
+  it("keeps user input when submission fails", async () => {
+    mockSubmission.onSubmit = vi.fn(async () => false);
+
+    render(<ContactForm content={getPortfolioContent("en").contact.form} />);
+
+    const user = userEvent.setup();
+    const nameInput = screen.getByLabelText("Name");
+    const emailInput = screen.getByLabelText("Email");
+    const subjectInput = screen.getByLabelText("Subject");
+    const messageInput = screen.getByLabelText("Message");
+
+    await user.type(nameInput, "Alp Talha Yazar");
+    await user.type(emailInput, "alp@example.com");
+    await user.type(subjectInput, "Backend collaboration");
+    await user.type(
+      messageInput,
+      "I would like to discuss a backend engineering opportunity."
+    );
+
+    await user.click(screen.getByRole("button", { name: /Send Message/i }));
+
+    expect(mockSubmission.onSubmit).toHaveBeenCalledTimes(1);
+    expect(nameInput).toHaveValue("Alp Talha Yazar");
+    expect(emailInput).toHaveValue("alp@example.com");
+    expect(subjectInput).toHaveValue("Backend collaboration");
+    expect(messageInput).toHaveValue(
+      "I would like to discuss a backend engineering opportunity."
+    );
+  });
+});

--- a/src/components/portfolio/ContactForm.tsx
+++ b/src/components/portfolio/ContactForm.tsx
@@ -37,8 +37,8 @@ export function ContactForm({ content }: ContactFormProps) {
   });
 
   const onSubmit = handleSubmit(async (data) => {
-    await submission.onSubmit(data);
-    if (!submission.submitError) {
+    const wasSuccessful = await submission.onSubmit(data);
+    if (wasSuccessful) {
       reset();
     }
   });

--- a/src/components/portfolio/ContactForm.tsx
+++ b/src/components/portfolio/ContactForm.tsx
@@ -1,0 +1,239 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { AlertTriangle, CheckCircle, Shield, Send } from "lucide-react";
+import type { ReactNode } from "react";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+
+import { type ContactFormData, SECURITY_CONSTANTS } from "@/types";
+import { useCSRFSecurity, useContactSubmission } from "@/hooks";
+import type { PortfolioContactContent } from "@/types/portfolio";
+
+interface ContactFormProps {
+  content: PortfolioContactContent["form"];
+}
+
+export function ContactForm({ content }: ContactFormProps) {
+  const security = useCSRFSecurity();
+  const submission = useContactSubmission(security);
+
+  const schema = z.object({
+    name: z.string().min(2, content.validation.nameRequired),
+    email: z.string().email(content.validation.emailInvalid),
+    subject: z.string().min(3, content.validation.subjectRequired),
+    message: z.string().min(10, content.validation.messageMinLength),
+    honeypot: z.string().optional(),
+    csrfToken: z.string().optional(),
+  });
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors, isSubmitting },
+  } = useForm<ContactFormData>({
+    resolver: zodResolver(schema),
+  });
+
+  const onSubmit = handleSubmit(async (data) => {
+    await submission.onSubmit(data);
+    if (!submission.submitError) {
+      reset();
+    }
+  });
+
+  const isDisabled =
+    isSubmitting ||
+    security.isSecurityLoading ||
+    !security.csrfToken ||
+    submission.isBlocked;
+
+  return (
+    <form onSubmit={onSubmit} className="surface-card space-y-6">
+      <input
+        {...register("honeypot")}
+        type="text"
+        tabIndex={-1}
+        autoComplete="off"
+        className="sr-only"
+        aria-hidden="true"
+      />
+
+      <div className="grid gap-6 sm:grid-cols-2">
+        <Field
+          label={content.nameLabel}
+          error={errors.name?.message}
+        >
+          <input
+            {...register("name")}
+            placeholder={content.placeholders.name}
+            aria-invalid={errors.name ? true : undefined}
+            className="input-shell"
+          />
+        </Field>
+
+        <Field
+          label={content.emailLabel}
+          error={errors.email?.message}
+        >
+          <input
+            {...register("email")}
+            type="email"
+            placeholder={content.placeholders.email}
+            aria-invalid={errors.email ? true : undefined}
+            className="input-shell"
+          />
+        </Field>
+      </div>
+
+      <Field
+        label={content.subjectLabel}
+        error={errors.subject?.message}
+      >
+        <input
+          {...register("subject")}
+          placeholder={content.placeholders.subject}
+          aria-invalid={errors.subject ? true : undefined}
+          className="input-shell"
+        />
+      </Field>
+
+      <Field
+        label={content.messageLabel}
+        error={errors.message?.message}
+      >
+        <textarea
+          {...register("message")}
+          rows={6}
+          placeholder={content.placeholders.message}
+          aria-invalid={errors.message ? true : undefined}
+          className="input-shell min-h-40 resize-y"
+        />
+      </Field>
+
+      <div className="space-y-3">
+        {security.isSecurityLoading ? (
+          <StatusLine icon={<Shield size={15} />} text={content.securityLoading} />
+        ) : null}
+        {!security.isSecurityLoading && security.csrfToken && !security.securityError ? (
+          <StatusLine icon={<Shield size={15} />} text={content.secured} success />
+        ) : null}
+        {security.securityError ? (
+          <Banner
+            icon={<AlertTriangle size={16} />}
+            text={security.securityError}
+            tone="error"
+          />
+        ) : null}
+        {submission.submitError ? (
+          <Banner
+            icon={<AlertTriangle size={16} />}
+            text={submission.submitError}
+            tone={submission.isBlocked ? "warning" : "error"}
+            meta={
+              submission.isBlocked && submission.blockInfo?.escalationLevel
+                ? `Level ${submission.blockInfo.escalationLevel}/${Object.keys(
+                    SECURITY_CONSTANTS.BLOCK_DURATIONS
+                  ).length}`
+                : undefined
+            }
+          />
+        ) : null}
+        {submission.isSubmitted ? (
+          <Banner
+            icon={<CheckCircle size={16} />}
+            text={content.success}
+            tone="success"
+          />
+        ) : null}
+      </div>
+
+      <button type="submit" disabled={isDisabled} className="primary-button w-full justify-center disabled:cursor-not-allowed disabled:opacity-50">
+        {isSubmitting ? (
+          <span>{content.submittingLabel}</span>
+        ) : submission.isBlocked ? (
+          <>
+            <AlertTriangle size={16} />
+            <span>{content.blocked}</span>
+          </>
+        ) : (
+          <>
+            <Send size={16} />
+            <span>{content.submitLabel}</span>
+          </>
+        )}
+      </button>
+    </form>
+  );
+}
+
+function Field({
+  label,
+  error,
+  children,
+}: {
+  label: string;
+  error?: string;
+  children: ReactNode;
+}) {
+  return (
+    <label className="block space-y-2">
+      <span className="mono-label text-muted-foreground">{label}</span>
+      {children}
+      {error ? <p className="text-sm text-error">{error}</p> : null}
+    </label>
+  );
+}
+
+function StatusLine({
+  icon,
+  text,
+  success = false,
+}: {
+  icon: ReactNode;
+  text: string;
+  success?: boolean;
+}) {
+  return (
+    <div
+      className={`inline-flex items-center gap-2 text-sm ${
+        success ? "text-accent" : "text-muted-foreground"
+      }`}
+    >
+      {icon}
+      <span>{text}</span>
+    </div>
+  );
+}
+
+function Banner({
+  icon,
+  text,
+  tone,
+  meta,
+}: {
+  icon: ReactNode;
+  text: string;
+  tone: "success" | "warning" | "error";
+  meta?: string;
+}) {
+  const toneClass =
+    tone === "success"
+      ? "border-accent/30 bg-accent/10 text-foreground"
+      : tone === "warning"
+      ? "border-orange-400/25 bg-orange-400/10 text-foreground"
+      : "border-error/30 bg-error/10 text-foreground";
+
+  return (
+    <div className={`rounded-2xl border px-4 py-3 ${toneClass}`}>
+      <div className="flex items-start gap-3">
+        {icon}
+        <div className="space-y-1">
+          <p className="text-sm leading-6">{text}</p>
+          {meta ? <p className="mono-label text-faint">{meta}</p> : null}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/portfolio/ContactSection.tsx
+++ b/src/components/portfolio/ContactSection.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { motion } from "framer-motion";
+
+import { contactDetails } from "@/lib/site";
+import type { PortfolioContactContent } from "@/types/portfolio";
+
+import { ContactForm } from "./ContactForm";
+import { SectionLabel } from "./SectionLabel";
+
+interface ContactSectionProps {
+  content: PortfolioContactContent;
+}
+
+export function ContactSection({ content }: ContactSectionProps) {
+  return (
+    <section id="contact" className="section-shell border-t border-border">
+      <div className="mx-auto max-w-6xl">
+        <SectionLabel
+          number={content.sectionNumber}
+          title={content.sectionTitle}
+        />
+
+        <div className="grid gap-12 lg:grid-cols-[1fr_1.05fr]">
+          <motion.div
+            initial={{ opacity: 0, y: 24 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true, margin: "-80px" }}
+            className="space-y-8"
+          >
+            <div className="space-y-5">
+              <h2 className="max-w-xl text-4xl font-semibold tracking-[-0.04em] text-foreground sm:text-5xl">
+                {content.headline}
+              </h2>
+              <p className="text-lg leading-8 text-muted-foreground">
+                {content.intro}
+              </p>
+              <p className="max-w-xl text-base leading-8 text-muted-foreground">
+                {content.body}
+              </p>
+            </div>
+
+            <div className="space-y-4">
+              {contactDetails.map((detail) => (
+                <a
+                  key={detail.label}
+                  href={detail.href}
+                  target={detail.href.startsWith("mailto:") ? undefined : "_blank"}
+                  rel={detail.href.startsWith("mailto:") ? undefined : "noreferrer"}
+                  className="flex items-center justify-between rounded-2xl border border-border bg-surface px-5 py-4 transition-colors hover:border-border-strong"
+                >
+                  <span className="mono-label text-muted-foreground">
+                    {detail.label}
+                  </span>
+                  <span className="text-sm text-foreground">↗</span>
+                </a>
+              ))}
+            </div>
+          </motion.div>
+
+          <motion.div
+            initial={{ opacity: 0, y: 24 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true, margin: "-80px" }}
+            transition={{ delay: 0.08 }}
+          >
+            <ContactForm content={content.form} />
+          </motion.div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/portfolio/Experience.tsx
+++ b/src/components/portfolio/Experience.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { motion } from "framer-motion";
+
+import type { PortfolioContent } from "@/types/portfolio";
+
+import { SectionLabel } from "./SectionLabel";
+
+interface ExperienceProps {
+  content: PortfolioContent["experience"];
+}
+
+export function Experience({ content }: ExperienceProps) {
+  return (
+    <section id="experience" className="section-shell border-t border-border bg-surface">
+      <div className="mx-auto max-w-6xl">
+        <SectionLabel
+          number={content.sectionNumber}
+          title={content.sectionTitle}
+        />
+        <h2 className="mb-14 max-w-2xl text-3xl font-semibold tracking-[-0.04em] text-foreground sm:text-4xl">
+          {content.intro}
+        </h2>
+
+        <div className="space-y-3">
+          {content.items.map((item, index) => (
+            <motion.article
+              key={item.number}
+              initial={{ opacity: 0, y: 24 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true, margin: "-60px" }}
+              transition={{ delay: index * 0.06 }}
+              className="surface-card"
+            >
+              <div className="mb-6 flex flex-wrap items-start justify-between gap-6">
+                <div>
+                  <div className="mb-3 flex items-center gap-3">
+                    <span className="mono-label text-accent">{item.number}</span>
+                    <div className="h-px w-5 bg-border" />
+                  </div>
+                  <h3 className="text-2xl font-semibold tracking-[-0.03em] text-foreground">
+                    {item.company}
+                  </h3>
+                  <p className="mt-1 text-sm text-muted-foreground">{item.role}</p>
+                </div>
+
+                <div className="text-left sm:text-right">
+                  <p className="mono-label text-muted-foreground">{item.period}</p>
+                  <p className="mt-2 text-sm text-faint">{item.location}</p>
+                </div>
+              </div>
+
+              <div className="section-divider" />
+
+              <p className="mb-7 max-w-3xl text-base leading-8 text-muted-foreground">
+                {item.description}
+              </p>
+
+              <div className="flex flex-wrap gap-2">
+                {item.tags.map((tag) => (
+                  <span key={tag} className="accent-chip">
+                    {tag}
+                  </span>
+                ))}
+              </div>
+            </motion.article>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/portfolio/Footer.tsx
+++ b/src/components/portfolio/Footer.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import type { PortfolioContent, PortfolioLocale } from "@/types/portfolio";
+
+import { socialLinks } from "@/lib/site";
+
+import { LanguageSwitcher } from "./LanguageSwitcher";
+
+interface FooterProps {
+  content: PortfolioContent["footer"];
+  nav: PortfolioContent["nav"];
+  locale: PortfolioLocale;
+}
+
+export function Footer({ content, nav, locale }: FooterProps) {
+  return (
+    <footer className="border-t border-border bg-surface px-5 py-10 sm:px-8">
+      <div className="mx-auto flex max-w-6xl flex-col gap-8 lg:flex-row lg:items-center lg:justify-between">
+        <div className="space-y-2">
+          <a href="#hero" className="mono-label text-foreground">
+            {nav.homeLabel}
+          </a>
+          <p className="mono-label text-muted-foreground">{content.strapline}</p>
+        </div>
+
+        <nav className="flex flex-wrap gap-6">
+          {nav.items.map((item) => (
+            <a
+              key={item.href}
+              href={item.href}
+              className="mono-label text-muted-foreground transition-colors hover:text-foreground"
+            >
+              {item.label}
+            </a>
+          ))}
+        </nav>
+
+        <div className="flex flex-col items-start gap-4 lg:items-end">
+          <LanguageSwitcher currentLocale={locale} label={nav.languageLabel} />
+          <div className="flex flex-wrap gap-4">
+            {socialLinks.map((link) => (
+              <a
+                key={link.label}
+                href={link.href}
+                target={link.href.startsWith("mailto:") ? undefined : "_blank"}
+                rel={link.href.startsWith("mailto:") ? undefined : "noreferrer"}
+                className="mono-label text-muted-foreground transition-colors hover:text-foreground"
+              >
+                {link.label}
+              </a>
+            ))}
+          </div>
+          <p className="text-sm text-faint">
+            © {new Date().getFullYear()} Alp Talha Yazar. {content.copyright}
+          </p>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/src/components/portfolio/Header.tsx
+++ b/src/components/portfolio/Header.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import { AnimatePresence, motion } from "framer-motion";
+import { Menu, X } from "lucide-react";
+import { useEffect, useState } from "react";
+
+import type { PortfolioContent, PortfolioLocale } from "@/types/portfolio";
+
+import { LanguageSwitcher } from "./LanguageSwitcher";
+
+interface HeaderProps {
+  nav: PortfolioContent["nav"];
+  locale: PortfolioLocale;
+}
+
+export function Header({ nav, locale }: HeaderProps) {
+  const [isScrolled, setIsScrolled] = useState(false);
+  const [isOpen, setIsOpen] = useState(false);
+
+  useEffect(() => {
+    const onScroll = () => setIsScrolled(window.scrollY > 40);
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => window.removeEventListener("scroll", onScroll);
+  }, []);
+
+  useEffect(() => {
+    document.body.style.overflow = isOpen ? "hidden" : "";
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [isOpen]);
+
+  return (
+    <>
+      <header
+        className={`fixed inset-x-0 top-0 z-50 transition-all duration-300 ${
+          isScrolled
+            ? "border-b border-border bg-background/90 backdrop-blur-xl"
+            : "bg-transparent"
+        }`}
+      >
+        <div className="mx-auto flex h-16 w-full max-w-6xl items-center justify-between px-5 sm:px-8">
+          <a href="#hero" className="mono-label text-foreground">
+            {nav.homeLabel}
+          </a>
+
+          <div className="hidden items-center gap-8 md:flex">
+            <nav className="flex items-center gap-8">
+              {nav.items.map((item) => (
+                <a
+                  key={item.href}
+                  href={item.href}
+                  className="mono-label text-muted-foreground transition-colors hover:text-foreground"
+                >
+                  {item.label}
+                </a>
+              ))}
+            </nav>
+            <LanguageSwitcher
+              currentLocale={locale}
+              label={nav.languageLabel}
+              compact
+            />
+            <a href="#contact" className="secondary-button">
+              {nav.letsTalkLabel}
+            </a>
+          </div>
+
+          <div className="flex items-center gap-3 md:hidden">
+            <LanguageSwitcher
+              currentLocale={locale}
+              label={nav.languageLabel}
+              compact
+            />
+            <button
+              type="button"
+              className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-border bg-surface text-foreground"
+              aria-label={isOpen ? nav.closeMenuLabel : nav.openMenuLabel}
+              onClick={() => setIsOpen((current) => !current)}
+            >
+              {isOpen ? <X size={18} /> : <Menu size={18} />}
+            </button>
+          </div>
+        </div>
+      </header>
+
+      <AnimatePresence>
+        {isOpen ? (
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            className="fixed inset-0 z-[60] bg-background"
+          >
+            <div className="mx-auto flex h-full max-w-6xl flex-col px-5 pb-8 pt-5">
+              <div className="flex items-center justify-between border-b border-border pb-5">
+                <span className="mono-label text-foreground">{nav.homeLabel}</span>
+                <button
+                  type="button"
+                  className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-border bg-surface text-foreground"
+                  aria-label={nav.closeMenuLabel}
+                  onClick={() => setIsOpen(false)}
+                >
+                  <X size={18} />
+                </button>
+              </div>
+
+              <div className="flex flex-1 flex-col justify-between py-10">
+                <div className="flex flex-col">
+                  {nav.items.map((item, index) => (
+                    <motion.a
+                      key={item.href}
+                      href={item.href}
+                      initial={{ opacity: 0, y: 18 }}
+                      animate={{ opacity: 1, y: 0 }}
+                      transition={{ delay: index * 0.06 }}
+                      className="border-b border-border py-5 text-4xl font-semibold tracking-[-0.04em] text-foreground"
+                      onClick={() => setIsOpen(false)}
+                    >
+                      {item.label}
+                    </motion.a>
+                  ))}
+                </div>
+
+                <div className="flex flex-col gap-6">
+                  <LanguageSwitcher currentLocale={locale} label={nav.languageLabel} />
+                  <a
+                    href="#contact"
+                    className="primary-button justify-center"
+                    onClick={() => setIsOpen(false)}
+                  >
+                    {nav.letsTalkLabel}
+                  </a>
+                </div>
+              </div>
+            </div>
+          </motion.div>
+        ) : null}
+      </AnimatePresence>
+    </>
+  );
+}

--- a/src/components/portfolio/Hero.tsx
+++ b/src/components/portfolio/Hero.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { ArrowDown } from "lucide-react";
+
+import { siteConfig } from "@/lib/site";
+import type { PortfolioHeroContent } from "@/types/portfolio";
+
+interface HeroProps {
+  content: PortfolioHeroContent;
+}
+
+export function Hero({ content }: HeroProps) {
+  return (
+    <section
+      id="hero"
+      className="relative flex min-h-screen items-center overflow-hidden px-5 pb-24 pt-28 sm:px-8"
+    >
+      <div className="absolute inset-0 shell-grid opacity-50" />
+
+      <div className="pointer-events-none absolute right-10 top-1/2 hidden -translate-y-1/2 lg:flex lg:flex-col lg:items-center lg:gap-4">
+        <div className="h-20 w-px bg-border" />
+        <span className="mono-label writing-vertical rotate-180 text-muted-foreground">
+          {content.availability}
+        </span>
+        <div className="h-20 w-px bg-border" />
+      </div>
+
+      <div className="relative z-10 mx-auto w-full max-w-6xl">
+        <motion.div
+          initial={{ opacity: 0, y: 12 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.6 }}
+          className="mb-10 flex items-center gap-3"
+        >
+          <div className="h-px w-8 bg-accent" />
+          <span className="mono-label text-accent">{content.eyebrow}</span>
+        </motion.div>
+
+        <motion.h1
+          initial={{ opacity: 0, y: 28 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.75, delay: 0.08 }}
+          className="max-w-5xl text-[clamp(3.5rem,10vw,7rem)] font-bold leading-[0.92] tracking-[-0.06em] text-foreground"
+        >
+          {content.headline}
+        </motion.h1>
+
+        <motion.p
+          initial={{ opacity: 0, y: 18 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.65, delay: 0.14 }}
+          className="mt-5 mono-label text-muted-foreground"
+        >
+          {siteConfig.fullName}
+        </motion.p>
+
+        <motion.p
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.65, delay: 0.2 }}
+          className="mt-8 max-w-xl text-balance text-lg leading-8 text-muted-foreground"
+        >
+          {content.supportingText}
+        </motion.p>
+
+        <motion.div
+          initial={{ opacity: 0, y: 14 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.55, delay: 0.28 }}
+          className="mt-10 flex flex-wrap gap-3"
+        >
+          <a href="#projects" className="primary-button">
+            {content.primaryCta}
+          </a>
+          <a href="#contact" className="secondary-button">
+            {content.secondaryCta}
+          </a>
+        </motion.div>
+
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ duration: 0.8, delay: 0.42 }}
+          className="mt-14 flex flex-wrap gap-2"
+        >
+          {content.techTags.map((tag) => (
+            <span key={tag} className="accent-chip">
+              {tag}
+            </span>
+          ))}
+        </motion.div>
+      </div>
+
+      <motion.a
+        href="#about"
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ delay: 1.1 }}
+        className="absolute bottom-8 left-1/2 z-10 inline-flex -translate-x-1/2 flex-col items-center gap-2 text-muted-foreground transition-colors hover:text-foreground"
+      >
+        <span className="mono-label">SCROLL</span>
+        <motion.span
+          animate={{ y: [0, 6, 0] }}
+          transition={{ repeat: Infinity, duration: 2.2, ease: "easeInOut" }}
+        >
+          <ArrowDown size={16} />
+        </motion.span>
+      </motion.a>
+    </section>
+  );
+}

--- a/src/components/portfolio/LanguageSwitcher.tsx
+++ b/src/components/portfolio/LanguageSwitcher.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
 
-import { buildLocalizedHref } from "@/lib/i18n/routing";
+import { buildLocalizedHref, publicPortfolioLocales } from "@/lib/i18n/routing";
 import type { PortfolioLocale } from "@/types/portfolio";
 
 const LABELS: Record<PortfolioLocale, string> = {
@@ -50,7 +50,7 @@ export function LanguageSwitcher({
         compact ? "" : "backdrop-blur"
       }`}
     >
-      {(Object.keys(LABELS) as PortfolioLocale[]).map((locale) => {
+      {publicPortfolioLocales.map((locale) => {
         const isActive = locale === currentLocale;
 
         return (

--- a/src/components/portfolio/LanguageSwitcher.tsx
+++ b/src/components/portfolio/LanguageSwitcher.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { useEffect, useMemo, useState } from "react";
+
+import { buildLocalizedHref } from "@/lib/i18n/routing";
+import type { PortfolioLocale } from "@/types/portfolio";
+
+const LABELS: Record<PortfolioLocale, string> = {
+  en: "EN",
+  tr: "TR",
+  es: "ES",
+};
+
+interface LanguageSwitcherProps {
+  currentLocale: PortfolioLocale;
+  label: string;
+  compact?: boolean;
+}
+
+export function LanguageSwitcher({
+  currentLocale,
+  label,
+  compact = false,
+}: LanguageSwitcherProps) {
+  const pathname = usePathname();
+  const [suffix, setSuffix] = useState("");
+
+  useEffect(() => {
+    const syncSuffix = () => {
+      setSuffix(`${window.location.search}${window.location.hash}`);
+    };
+
+    syncSuffix();
+    window.addEventListener("hashchange", syncSuffix);
+
+    return () => window.removeEventListener("hashchange", syncSuffix);
+  }, [pathname]);
+
+  const baseHref = useMemo(
+    () => `${pathname || "/"}${suffix}`,
+    [pathname, suffix]
+  );
+
+  return (
+    <div
+      aria-label={label}
+      className={`inline-flex items-center gap-1 rounded-full border border-border bg-surface/90 p-1 ${
+        compact ? "" : "backdrop-blur"
+      }`}
+    >
+      {(Object.keys(LABELS) as PortfolioLocale[]).map((locale) => {
+        const isActive = locale === currentLocale;
+
+        return (
+          <Link
+            key={locale}
+            href={buildLocalizedHref(locale, baseHref)}
+            aria-current={isActive ? "page" : undefined}
+            className={`rounded-full px-2.5 py-1 text-[11px] font-medium tracking-[0.18em] transition-colors ${
+              isActive
+                ? "bg-accent text-accent-foreground"
+                : "text-muted-foreground hover:text-foreground"
+            }`}
+          >
+            {LABELS[locale]}
+          </Link>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/portfolio/NotFoundPage.tsx
+++ b/src/components/portfolio/NotFoundPage.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import Link from "next/link";
+import { motion } from "framer-motion";
+
+import { buildLocalizedHref } from "@/lib/i18n/routing";
+import type { PortfolioLocale, PortfolioNotFoundContent } from "@/types/portfolio";
+
+interface NotFoundPageProps {
+  content: PortfolioNotFoundContent;
+  locale: PortfolioLocale;
+}
+
+export function NotFoundPage({ content, locale }: NotFoundPageProps) {
+  return (
+    <div className="relative flex min-h-screen items-center justify-center overflow-hidden px-5 py-24 sm:px-8">
+      <div className="absolute inset-0 shell-grid opacity-50" />
+
+      <motion.div
+        initial={{ opacity: 0, y: 24 }}
+        animate={{ opacity: 1, y: 0 }}
+        className="relative z-10 mx-auto max-w-2xl text-center"
+      >
+        <div className="mb-7 flex items-center justify-center gap-3">
+          <div className="h-px w-8 bg-accent" />
+          <span className="mono-label text-accent">{content.eyebrow}</span>
+          <div className="h-px w-8 bg-accent" />
+        </div>
+        <p className="text-[clamp(6rem,16vw,11rem)] font-bold leading-none tracking-[-0.08em] text-surface-2">
+          404
+        </p>
+        <h1 className="mt-4 text-4xl font-semibold tracking-[-0.05em] text-foreground sm:text-5xl">
+          {content.title}
+        </h1>
+        <p className="mx-auto mt-4 max-w-xl text-lg leading-8 text-muted-foreground">
+          {content.description}
+        </p>
+
+        <div className="mt-10 flex justify-center gap-3">
+          <Link href={buildLocalizedHref(locale, "/")} className="primary-button">
+            {content.primaryCta}
+          </Link>
+          <button
+            type="button"
+            className="secondary-button"
+            onClick={() => window.history.back()}
+          >
+            {content.secondaryCta}
+          </button>
+        </div>
+      </motion.div>
+    </div>
+  );
+}

--- a/src/components/portfolio/PortfolioPage.tsx
+++ b/src/components/portfolio/PortfolioPage.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import type { PortfolioContent, PortfolioLocale } from "@/types/portfolio";
+
+import { About } from "./About";
+import { Capabilities } from "./Capabilities";
+import { ContactSection } from "./ContactSection";
+import { Experience } from "./Experience";
+import { Footer } from "./Footer";
+import { Header } from "./Header";
+import { Hero } from "./Hero";
+import { Projects } from "./Projects";
+
+interface PortfolioPageProps {
+  content: PortfolioContent;
+  locale: PortfolioLocale;
+}
+
+export function PortfolioPage({ content, locale }: PortfolioPageProps) {
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      <Header nav={content.nav} locale={locale} />
+      <main id="main-content" tabIndex={-1}>
+        <Hero content={content.hero} />
+        <About content={content.about} />
+        <Experience content={content.experience} />
+        <Projects content={content.projects} />
+        <Capabilities content={content.capabilities} />
+        <ContactSection content={content.contact} />
+      </main>
+      <Footer content={content.footer} nav={content.nav} locale={locale} />
+    </div>
+  );
+}

--- a/src/components/portfolio/Projects.tsx
+++ b/src/components/portfolio/Projects.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { motion } from "framer-motion";
+
+import type { PortfolioContent } from "@/types/portfolio";
+
+import { SectionLabel } from "./SectionLabel";
+
+interface ProjectsProps {
+  content: PortfolioContent["projects"];
+}
+
+export function Projects({ content }: ProjectsProps) {
+  return (
+    <section id="projects" className="section-shell border-t border-border">
+      <div className="mx-auto max-w-6xl">
+        <SectionLabel
+          number={content.sectionNumber}
+          title={content.sectionTitle}
+        />
+        <h2 className="mb-14 max-w-2xl text-3xl font-semibold tracking-[-0.04em] text-foreground sm:text-4xl">
+          {content.intro}
+        </h2>
+
+        <div className="grid gap-3 xl:grid-cols-2">
+          {content.items.map((item, index) => (
+            <motion.article
+              key={item.number}
+              initial={{ opacity: 0, y: 28 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true, margin: "-60px" }}
+              transition={{ delay: index * 0.05 }}
+              className="surface-card flex h-full flex-col"
+            >
+              <div className="mb-7 flex items-center justify-between gap-4">
+                <span className="mono-label text-accent">{item.number}</span>
+                <span className="mono-label text-muted-foreground">
+                  {item.company}
+                </span>
+              </div>
+
+              <h3 className="mb-4 text-2xl font-semibold tracking-[-0.03em] text-foreground">
+                {item.name}
+              </h3>
+
+              <div className="mb-5 flex flex-wrap gap-2">
+                {item.themes.map((theme) => (
+                  <span key={theme} className="theme-chip">
+                    {theme}
+                  </span>
+                ))}
+              </div>
+
+              <p className="flex-1 text-base leading-8 text-muted-foreground">
+                {item.description}
+              </p>
+
+              <div className="section-divider mt-7" />
+
+              <div className="mt-6 flex flex-wrap gap-2">
+                {item.tags.map((tag) => (
+                  <span key={tag} className="accent-chip">
+                    {tag}
+                  </span>
+                ))}
+              </div>
+            </motion.article>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/portfolio/SectionLabel.tsx
+++ b/src/components/portfolio/SectionLabel.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+interface SectionLabelProps {
+  number: string;
+  title: string;
+}
+
+export function SectionLabel({ number, title }: SectionLabelProps) {
+  return (
+    <div className="mb-16 flex items-center gap-4">
+      <span className="mono-label text-accent">{number}</span>
+      <div className="h-px w-10 bg-border" />
+      <span className="mono-label text-muted-foreground">{title}</span>
+    </div>
+  );
+}

--- a/src/components/portfolio/index.ts
+++ b/src/components/portfolio/index.ts
@@ -1,0 +1,12 @@
+export { About } from "./About";
+export { Capabilities } from "./Capabilities";
+export { ContactSection } from "./ContactSection";
+export { Experience } from "./Experience";
+export { Footer } from "./Footer";
+export { Header } from "./Header";
+export { Hero } from "./Hero";
+export { LanguageSwitcher } from "./LanguageSwitcher";
+export { NotFoundPage } from "./NotFoundPage";
+export { PortfolioPage } from "./PortfolioPage";
+export { Projects } from "./Projects";
+export { SectionLabel } from "./SectionLabel";

--- a/src/components/utils/StructuredData.test.tsx
+++ b/src/components/utils/StructuredData.test.tsx
@@ -1,0 +1,31 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import StructuredData from "./StructuredData";
+
+function getStructuredData(locale: "en" | "tr") {
+  const { container } = render(<StructuredData locale={locale} />);
+  const script = container.querySelector(
+    'script[type="application/ld+json"]'
+  );
+
+  return JSON.parse(script?.innerHTML ?? "{}");
+}
+
+describe("StructuredData", () => {
+  it("matches the root canonical URL format", () => {
+    const data = getStructuredData("en");
+
+    expect(data["@graph"][0].url).toBe("https://www.alptalha.dev/");
+    expect(data["@graph"][1].url).toBe("https://www.alptalha.dev/");
+    expect(data["@graph"][2].url).toBe("https://www.alptalha.dev/");
+  });
+
+  it("matches localized canonical URL format", () => {
+    const data = getStructuredData("tr");
+
+    expect(data["@graph"][0].url).toBe("https://www.alptalha.dev/tr/");
+    expect(data["@graph"][1].url).toBe("https://www.alptalha.dev/tr/");
+    expect(data["@graph"][2].url).toBe("https://www.alptalha.dev/tr/");
+  });
+});

--- a/src/components/utils/StructuredData.tsx
+++ b/src/components/utils/StructuredData.tsx
@@ -1,275 +1,85 @@
-export default function StructuredData() {
-  // Main Person schema
-  const personSchema = {
-    "@context": "https://schema.org",
-    "@type": "Person",
-    "@id": "https://www.alptalha.dev/#person",
-    name: "Alp Talha Yazar",
-    givenName: "Alp Talha",
-    familyName: "Yazar",
-    jobTitle: "Senior Backend Developer",
-    description:
-      "Senior Backend Developer with 5+ years experience in .NET, C#, microservices, and enterprise applications. Specializing in scalable B2B/B2G solutions, PostgreSQL databases, and cloud technologies.",
-    url: "https://www.alptalha.dev",
-    mainEntityOfPage: {
-      "@type": "WebPage",
-      "@id": "https://www.alptalha.dev",
-    },
-    image: {
-      "@type": "ImageObject",
-      url: "https://www.alptalha.dev/profile-photo.jpg",
-      width: 400,
-      height: 400,
-      caption: "Alp Talha Yazar - Senior Backend Developer",
-    },
-    sameAs: [
-      "https://github.com/alptalha",
-      "https://linkedin.com/in/alptalha",
-      "https://twitter.com/alptalha_dev",
-      "https://www.alptalha.dev",
-    ],
-    worksFor: {
-      "@type": "Organization",
-      name: "Freelance Software Developer",
-      url: "https://www.alptalha.dev",
-    },
-    hasOccupation: {
-      "@type": "Occupation",
-      name: "Senior Backend Developer",
-      occupationLocation: {
-        "@type": "Place",
-        name: "Turkey",
-        address: {
-          "@type": "PostalAddress",
-          addressCountry: "TR",
-          addressRegion: "Turkey",
-        },
+import { getPortfolioContent } from "@/lib/content/portfolio";
+import { siteConfig } from "@/lib/site";
+import type { PortfolioLocale } from "@/types/portfolio";
+
+interface StructuredDataProps {
+  locale: PortfolioLocale;
+}
+
+export default function StructuredData({ locale }: StructuredDataProps) {
+  const content = getPortfolioContent(locale);
+  const canonical = locale === "en" ? siteConfig.baseUrl : `${siteConfig.baseUrl}/${locale}`;
+
+  const graph = [
+    {
+      "@type": "Person",
+      "@id": `${siteConfig.baseUrl}/#person`,
+      name: siteConfig.fullName,
+      jobTitle: "Senior Backend Engineer",
+      description: content.metadata.description,
+      url: canonical,
+      sameAs: [siteConfig.githubUrl, siteConfig.linkedInUrl, siteConfig.baseUrl],
+      address: {
+        "@type": "PostalAddress",
+        addressCountry: "TR",
+        addressRegion: siteConfig.location,
       },
-      skills: [
+      contactPoint: {
+        "@type": "ContactPoint",
+        contactType: "professional",
+        email: siteConfig.email,
+        availableLanguage: ["English", "Turkish", "Spanish"],
+      },
+      knowsAbout: [
         ".NET",
         "C#",
         "ASP.NET Core",
-        "Entity Framework",
-        "PostgreSQL",
         "Microservices",
-        "RESTful APIs",
-        "TypeScript",
-        "React",
-        "Next.js",
-        "Azure",
-        "AWS",
+        "PostgreSQL",
+        "Redis",
         "Docker",
+        "Kubernetes",
         "System Architecture",
-        "Clean Architecture",
-      ],
-      experienceRequirements: "5+ years",
-      educationRequirements: "Computer Science degree or equivalent experience",
-    },
-    knowsAbout: [
-      {
-        "@type": "Thing",
-        name: ".NET Framework",
-        description: "Microsoft's development platform",
-      },
-      {
-        "@type": "Thing",
-        name: "C# Programming",
-        description: "Object-oriented programming language",
-      },
-      {
-        "@type": "Thing",
-        name: "Microservices Architecture",
-        description: "Distributed system design pattern",
-      },
-      {
-        "@type": "Thing",
-        name: "PostgreSQL",
-        description: "Advanced open-source relational database",
-      },
-      {
-        "@type": "Thing",
-        name: "Enterprise Applications",
-        description: "Large-scale business software systems",
-      },
-      {
-        "@type": "Thing",
-        name: "B2B Software Development",
-        description: "Business-to-business application development",
-      },
-    ],
-    address: {
-      "@type": "PostalAddress",
-      addressCountry: "Turkey",
-      addressRegion: "TR",
-    },
-    contactPoint: {
-      "@type": "ContactPoint",
-      contactType: "professional",
-      email: process.env.NEXT_PUBLIC_CONTACT_EMAIL || "contact@alptalha.dev",
-      url: "https://www.alptalha.dev/#contact",
-      availableLanguage: ["English", "Turkish", "Spanish"],
-    },
-    alumniOf: {
-      "@type": "EducationalOrganization",
-      name: "Computer Science Education",
-    },
-    hasCredential: [
-      {
-        "@type": "EducationalOccupationalCredential",
-        credentialCategory: "degree",
-        competencyRequired: "Software Development",
-        educationalLevel: "Bachelor's Degree",
-      },
-    ],
-    award: [
-      "5+ Years Backend Development Experience",
-      "Enterprise Application Architecture",
-      "Microservices Implementation Expert",
-    ],
-  };
-
-  // WebSite schema
-  const websiteSchema = {
-    "@context": "https://schema.org",
-    "@type": "WebSite",
-    "@id": "https://www.alptalha.dev/#website",
-    name: "Alp Talha Yazar - Portfolio",
-    description:
-      "Professional portfolio showcasing backend development expertise, projects, and experience",
-    url: "https://www.alptalha.dev",
-    author: {
-      "@id": "https://www.alptalha.dev/#person",
-    },
-    publisher: {
-      "@id": "https://www.alptalha.dev/#person",
-    },
-    inLanguage: "en-US",
-    copyrightYear: new Date().getFullYear(),
-    copyrightHolder: {
-      "@id": "https://www.alptalha.dev/#person",
-    },
-    potentialAction: {
-      "@type": "SearchAction",
-      target: {
-        "@type": "EntryPoint",
-        urlTemplate: "https://www.alptalha.dev/search?q={search_term_string}",
-      },
-      "query-input": "required name=search_term_string",
-    },
-  };
-
-  // Professional Service schema
-  const professionalServiceSchema = {
-    "@context": "https://schema.org",
-    "@type": "ProfessionalService",
-    "@id": "https://www.alptalha.dev/#service",
-    name: "Backend Development Services",
-    description:
-      "Professional backend development services specializing in .NET, microservices, and enterprise applications",
-    provider: {
-      "@id": "https://www.alptalha.dev/#person",
-    },
-    areaServed: {
-      "@type": "Place",
-      name: "Worldwide (Remote)",
-    },
-    serviceType: [
-      "Backend Development",
-      "API Development",
-      "Microservices Architecture",
-      "Database Design",
-      "System Integration",
-      "Technical Consulting",
-    ],
-    hasOfferCatalog: {
-      "@type": "OfferCatalog",
-      name: "Development Services",
-      itemListElement: [
-        {
-          "@type": "Offer",
-          itemOffered: {
-            "@type": "Service",
-            name: ".NET Backend Development",
-            description:
-              "Full-stack .NET application development with C# and modern frameworks",
-          },
-        },
-        {
-          "@type": "Offer",
-          itemOffered: {
-            "@type": "Service",
-            name: "Microservices Architecture",
-            description:
-              "Design and implementation of scalable microservices systems",
-          },
-        },
-        {
-          "@type": "Offer",
-          itemOffered: {
-            "@type": "Service",
-            name: "API Development",
-            description:
-              "RESTful API design and development with proper documentation",
-          },
-        },
       ],
     },
-  };
-
-  // BreadcrumbList schema
-  const breadcrumbSchema = {
-    "@context": "https://schema.org",
-    "@type": "BreadcrumbList",
-    itemListElement: [
-      {
-        "@type": "ListItem",
-        position: 1,
-        name: "Home",
-        item: "https://www.alptalha.dev",
+    {
+      "@type": "WebSite",
+      "@id": `${siteConfig.baseUrl}/#website`,
+      name: siteConfig.fullName,
+      url: canonical,
+      description: content.metadata.description,
+      inLanguage: locale,
+      publisher: {
+        "@id": `${siteConfig.baseUrl}/#person`,
       },
-      {
-        "@type": "ListItem",
-        position: 2,
-        name: "About",
-        item: "https://www.alptalha.dev/#about",
+    },
+    {
+      "@type": "ProfessionalService",
+      "@id": `${siteConfig.baseUrl}/#service`,
+      name: "Backend Engineering Services",
+      url: canonical,
+      description: content.contact.body,
+      provider: {
+        "@id": `${siteConfig.baseUrl}/#person`,
       },
-      {
-        "@type": "ListItem",
-        position: 3,
-        name: "Experience",
-        item: "https://www.alptalha.dev/#experience",
-      },
-      {
-        "@type": "ListItem",
-        position: 4,
-        name: "Projects",
-        item: "https://www.alptalha.dev/#projects",
-      },
-      {
-        "@type": "ListItem",
-        position: 5,
-        name: "Contact",
-        item: "https://www.alptalha.dev/#contact",
-      },
-    ],
-  };
-
-  // Combine all schemas
-  const combinedSchema = {
-    "@context": "https://schema.org",
-    "@graph": [
-      personSchema,
-      websiteSchema,
-      professionalServiceSchema,
-      breadcrumbSchema,
-    ],
-  };
+      areaServed: "Worldwide",
+      serviceType: [
+        "Backend Development",
+        "API Development",
+        "System Design",
+        "Technical Consulting",
+      ],
+    },
+  ];
 
   return (
     <script
       type="application/ld+json"
       dangerouslySetInnerHTML={{
-        __html: JSON.stringify(combinedSchema, null, 0),
+        __html: JSON.stringify({
+          "@context": "https://schema.org",
+          "@graph": graph,
+        }),
       }}
     />
   );

--- a/src/components/utils/StructuredData.tsx
+++ b/src/components/utils/StructuredData.tsx
@@ -1,4 +1,5 @@
 import { getPortfolioContent } from "@/lib/content/portfolio";
+import { getCanonicalUrl } from "@/lib/seo/portfolio-metadata";
 import { siteConfig } from "@/lib/site";
 import type { PortfolioLocale } from "@/types/portfolio";
 
@@ -8,7 +9,7 @@ interface StructuredDataProps {
 
 export default function StructuredData({ locale }: StructuredDataProps) {
   const content = getPortfolioContent(locale);
-  const canonical = locale === "en" ? siteConfig.baseUrl : `${siteConfig.baseUrl}/${locale}`;
+  const canonical = getCanonicalUrl(locale);
 
   const graph = [
     {

--- a/src/components/utils/StructuredData.tsx
+++ b/src/components/utils/StructuredData.tsx
@@ -28,7 +28,7 @@ export default function StructuredData({ locale }: StructuredDataProps) {
         "@type": "ContactPoint",
         contactType: "professional",
         email: siteConfig.email,
-        availableLanguage: ["English", "Turkish", "Spanish"],
+        availableLanguage: ["English", "Turkish"],
       },
       knowsAbout: [
         ".NET",

--- a/src/hooks/useCSRFSecurity.test.tsx
+++ b/src/hooks/useCSRFSecurity.test.tsx
@@ -1,0 +1,54 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { SECURITY_CONSTANTS } from "@/types";
+
+import { useCSRFSecurity } from "./useCSRFSecurity";
+
+const SECURITY_STORAGE_KEY = "portfolio.csrf-security";
+
+describe("useCSRFSecurity", () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    sessionStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it("reuses a persisted valid security session without refetching", async () => {
+    sessionStorage.setItem(
+      SECURITY_STORAGE_KEY,
+      JSON.stringify({
+        csrfToken: "persisted-token",
+        sessionId: "persisted-session",
+        tokenExpires:
+          Date.now() + SECURITY_CONSTANTS.CSRF_REFRESH_THRESHOLD + 60_000,
+      })
+    );
+
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        token: "fresh-token",
+        sessionId: "fresh-session",
+        expires: Date.now() + 3_600_000,
+      }),
+    });
+    global.fetch = fetchMock as typeof fetch;
+
+    const { result } = renderHook(() => useCSRFSecurity());
+
+    await waitFor(() => {
+      expect(result.current.isSecurityLoading).toBe(false);
+    });
+
+    expect(result.current.csrfToken).toBe("persisted-token");
+    expect(result.current.sessionId).toBe("persisted-session");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useCSRFSecurity.ts
+++ b/src/hooks/useCSRFSecurity.ts
@@ -2,6 +2,63 @@ import { useState, useEffect, useCallback, useRef } from "react";
 import { SECURITY_CONSTANTS, type CSRFTokenResponse } from "@/types";
 import { logger } from "@/lib/logger";
 
+const SECURITY_STORAGE_KEY = "portfolio.csrf-security";
+
+interface PersistedSecurityState {
+  csrfToken: string;
+  sessionId: string;
+  tokenExpires: number;
+}
+
+function loadPersistedSecurityState(): PersistedSecurityState | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  const rawValue = window.sessionStorage.getItem(SECURITY_STORAGE_KEY);
+  if (!rawValue) {
+    return null;
+  }
+
+  try {
+    const parsedValue = JSON.parse(rawValue) as Partial<PersistedSecurityState>;
+
+    if (
+      typeof parsedValue.csrfToken !== "string" ||
+      typeof parsedValue.sessionId !== "string" ||
+      typeof parsedValue.tokenExpires !== "number"
+    ) {
+      window.sessionStorage.removeItem(SECURITY_STORAGE_KEY);
+      return null;
+    }
+
+    return {
+      csrfToken: parsedValue.csrfToken,
+      sessionId: parsedValue.sessionId,
+      tokenExpires: parsedValue.tokenExpires,
+    };
+  } catch {
+    window.sessionStorage.removeItem(SECURITY_STORAGE_KEY);
+    return null;
+  }
+}
+
+function persistSecurityState(state: PersistedSecurityState): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  window.sessionStorage.setItem(SECURITY_STORAGE_KEY, JSON.stringify(state));
+}
+
+function clearPersistedSecurityState(): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  window.sessionStorage.removeItem(SECURITY_STORAGE_KEY);
+}
+
 // Hook return type
 export interface UseCSRFSecurityReturn {
   // Token state
@@ -105,6 +162,11 @@ export const useCSRFSecurity = (): UseCSRFSecurityReturn => {
       setCsrfToken(data.token);
       setSessionId(data.sessionId);
       setTokenExpires(data.expires);
+      persistSecurityState({
+        csrfToken: data.token,
+        sessionId: data.sessionId,
+        tokenExpires: data.expires,
+      });
       setIsSecurityLoading(false);
 
       return true;
@@ -116,6 +178,7 @@ export const useCSRFSecurity = (): UseCSRFSecurityReturn => {
           ? error.message
           : "Security initialization failed"
       );
+      clearPersistedSecurityState();
 
       setIsSecurityLoading(false);
       return false;
@@ -136,6 +199,24 @@ export const useCSRFSecurity = (): UseCSRFSecurityReturn => {
       }
 
       try {
+        const persistedState = loadPersistedSecurityState();
+
+        if (persistedState) {
+          sessionIdRef.current = persistedState.sessionId;
+          setCsrfToken(persistedState.csrfToken);
+          setSessionId(persistedState.sessionId);
+          setTokenExpires(persistedState.tokenExpires);
+
+          if (
+            persistedState.tokenExpires >
+            Date.now() + SECURITY_CONSTANTS.CSRF_REFRESH_THRESHOLD
+          ) {
+            logger.dev.log("Reusing persisted CSRF token from session storage");
+            setIsSecurityLoading(false);
+            return;
+          }
+        }
+
         isFetchingRef.current = true;
         setIsSecurityLoading(true);
         setSecurityError(null);
@@ -172,6 +253,11 @@ export const useCSRFSecurity = (): UseCSRFSecurityReturn => {
         setCsrfToken(data.token);
         setSessionId(data.sessionId);
         setTokenExpires(data.expires);
+        persistSecurityState({
+          csrfToken: data.token,
+          sessionId: data.sessionId,
+          tokenExpires: data.expires,
+        });
         setIsSecurityLoading(false);
       } catch (error) {
         logger.error("Failed to initialize security:", error);
@@ -181,6 +267,7 @@ export const useCSRFSecurity = (): UseCSRFSecurityReturn => {
             ? error.message
             : "Security initialization failed"
         );
+        clearPersistedSecurityState();
 
         setIsSecurityLoading(false);
       } finally {

--- a/src/hooks/useContactSubmission.ts
+++ b/src/hooks/useContactSubmission.ts
@@ -12,7 +12,7 @@ export interface UseContactSubmissionReturn {
   blockInfo: { escalationLevel?: number } | null;
 
   // Functions
-  onSubmit: (data: ContactFormData) => Promise<void>;
+  onSubmit: (data: ContactFormData) => Promise<boolean>;
   clearSubmitError: () => void;
   resetSubmissionState: () => void;
 }
@@ -64,7 +64,7 @@ export const useContactSubmission = (
   };
 
   // Form submission handler
-  const onSubmit = async (data: ContactFormData): Promise<void> => {
+  const onSubmit = async (data: ContactFormData): Promise<boolean> => {
     try {
       setSubmitError(null);
       security.clearSecurityError();
@@ -159,6 +159,7 @@ export const useContactSubmission = (
       }
 
       successTimeoutRef.current = setTimeout(() => setIsSubmitted(false), 5000);
+      return true;
     } catch (error) {
       logger.error("Error sending email:", error);
 
@@ -176,6 +177,7 @@ export const useContactSubmission = (
         () => setSubmitError(null),
         10000
       );
+      return false;
     }
   };
 

--- a/src/lib/content/portfolio/en.ts
+++ b/src/lib/content/portfolio/en.ts
@@ -1,0 +1,274 @@
+import type { PortfolioContent } from "@/types/portfolio";
+
+export const portfolioContentEn: PortfolioContent = {
+  locale: "en",
+  metadata: {
+    title: "Alp Talha Yazar | Senior Backend Engineer",
+    description:
+      "Senior Backend Engineer building reliable enterprise systems, APIs, and distributed platforms for real production environments.",
+  },
+  nav: {
+    homeLabel: "ATY",
+    items: [
+      { label: "Projects", href: "#projects" },
+      { label: "Experience", href: "#experience" },
+      { label: "About", href: "#about" },
+      { label: "Contact", href: "#contact" },
+    ],
+    languageLabel: "Language",
+    letsTalkLabel: "Let's Talk",
+    closeMenuLabel: "Close navigation",
+    openMenuLabel: "Open navigation",
+  },
+  hero: {
+    eyebrow: "SENIOR BACKEND ENGINEER",
+    availability: "AVAILABLE FOR REMOTE WORK",
+    headline: "I build backend systems that stay reliable under real load.",
+    supportingText:
+      "Architecture, reliability, and scale for enterprise software in production.",
+    primaryCta: "View Selected Work",
+    secondaryCta: "Start a Conversation",
+    techTags: [
+      ".NET 9",
+      "C#",
+      "ASP.NET Core",
+      "Microservices",
+      "PostgreSQL",
+      "Redis",
+      "Docker",
+      "Kubernetes",
+    ],
+  },
+  about: {
+    sectionNumber: "02",
+    sectionTitle: "ABOUT",
+    lead: "A software engineer who builds backend systems that hold up under real conditions.",
+    paragraphs: [
+      "I work on the parts of a product that have to stay dependable when the system gets busy: APIs, service boundaries, data flows, queues, deployments, and the operational decisions around them.",
+      "My strongest work has been in enterprise B2B and B2G software, AI infrastructure, and platform-style systems where correctness, maintainability, and observability matter as much as shipping features.",
+      "I build primarily with .NET and C#, work comfortably with PostgreSQL, Redis, Docker, and Kubernetes, and can move across the stack when a product needs someone who understands both delivery and architecture.",
+    ],
+    statusPill: "Based in Turkey · Open to remote opportunities",
+  },
+  experience: {
+    sectionNumber: "03",
+    sectionTitle: "EXPERIENCE",
+    intro: "Four-plus years building systems that need to keep operating under real production constraints.",
+    items: [
+      {
+        number: "01",
+        company: "Dias (Atlastek)",
+        role: "Backend Developer",
+        period: "2023 - Present",
+        location: "Turkey",
+        description:
+          "Building enterprise-level B2G tracking and management systems for regulated environments. Focused on service reliability, data-heavy workflows, operational visibility, and backend architecture across a distributed production stack.",
+        tags: [
+          ".NET 9",
+          "C#",
+          "Entity Framework Core",
+          "PostgreSQL",
+          "Redis",
+          "RabbitMQ",
+          "Docker",
+          "Kubernetes",
+        ],
+      },
+      {
+        number: "02",
+        company: "Wiro AI",
+        role: "Software Engineer",
+        period: "Jul 2023 - Aug 2024",
+        location: "Istanbul, Turkey",
+        description:
+          "Built AI/ML infrastructure spanning Linux GPU workers, model-testing interfaces, LLM request distribution, APIs, and live monitoring. Worked close to orchestration, internal tooling, and systems that needed clear operational visibility.",
+        tags: [
+          ".NET 8",
+          "Blazor",
+          "PostgreSQL",
+          "Redis",
+          "Docker",
+          "Linux",
+          "SignalR",
+          "Tailwind CSS",
+        ],
+      },
+      {
+        number: "03",
+        company: "Jetlink",
+        role: "Full Stack Developer",
+        period: "2021 - 2022",
+        location: "Turkey",
+        description:
+          "Delivered a multi-project chatbot platform covering CMS, REST APIs, end-user UI, reporting, and integrations. Led legacy-to-modern migration work and shipped across both backend-heavy and product-facing layers.",
+        tags: [
+          ".NET 6",
+          "ASP.NET MVC",
+          "MongoDB",
+          "WebSockets",
+          "React",
+          "TypeScript",
+          "IIS",
+        ],
+      },
+    ],
+  },
+  projects: {
+    sectionNumber: "04",
+    sectionTitle: "SELECTED WORK",
+    intro: "Systems built in production, not in demos.",
+    items: [
+      {
+        number: "01",
+        name: "Enterprise Management Platform",
+        company: "Dias (Atlastek)",
+        description:
+          "Real-time operational monitoring and tracking for enterprise clients in regulated sectors, built around high uptime, large-scale event flows, and service-to-service coordination.",
+        themes: [
+          "Operational reliability",
+          "Real-time monitoring",
+          "Large-scale data flows",
+        ],
+        tags: [".NET 9", "PostgreSQL", "Redis", "RabbitMQ", "Docker", "Kubernetes"],
+      },
+      {
+        number: "02",
+        name: "Enterprise Asset Tracking System",
+        company: "Dias (Atlastek)",
+        description:
+          "Multi-tenant asset tracking and reporting system for compliance-heavy environments where auditability, domain clarity, and stable backend contracts mattered.",
+        themes: [
+          "Regulated environments",
+          "Multi-tenant architecture",
+          "Reporting and compliance",
+        ],
+        tags: [".NET 9", "C#", "Entity Framework Core", "PostgreSQL", "Docker"],
+      },
+      {
+        number: "03",
+        name: "Wiro AI ML Infrastructure Platform",
+        company: "Wiro AI",
+        description:
+          "Infrastructure platform for AI/ML operations: GPU workers, request distribution, model-testing workflows, and live monitoring, built to make internal systems more observable and operable.",
+        themes: [
+          "GPU worker orchestration",
+          "Request distribution",
+          "System visibility",
+        ],
+        tags: [".NET 8", "Redis", "PostgreSQL", "Docker", "Linux", "SignalR"],
+      },
+      {
+        number: "04",
+        name: "Jetlink Multi-Project Chatbot Platform",
+        company: "Jetlink",
+        description:
+          "Full-stack chatbot platform spanning CMS, APIs, reporting, integrations, and end-user UI, including a legacy .NET modernization path and real-time communication workflows.",
+        themes: [
+          "Platform architecture",
+          "Legacy modernization",
+          "Integration-heavy systems",
+        ],
+        tags: [".NET 6", "MongoDB", "WebSockets", "React", "TypeScript", "IIS"],
+      },
+    ],
+  },
+  capabilities: {
+    sectionNumber: "05",
+    sectionTitle: "CAPABILITIES",
+    groups: [
+      {
+        category: "Backend",
+        items: [
+          ".NET / C#",
+          "ASP.NET Core",
+          "REST API design",
+          "Microservices",
+          "Entity Framework Core",
+          "SignalR",
+        ],
+      },
+      {
+        category: "Data",
+        items: [
+          "PostgreSQL",
+          "Redis",
+          "MongoDB",
+          "SQL Server",
+          "Data modeling",
+          "Query performance",
+        ],
+      },
+      {
+        category: "Platform",
+        items: [
+          "Docker",
+          "Kubernetes",
+          "Linux",
+          "CI/CD thinking",
+          "Operational readiness",
+          "Environment management",
+        ],
+      },
+      {
+        category: "Full Stack Fluency",
+        items: [
+          "React",
+          "Next.js",
+          "TypeScript",
+          "Blazor",
+          "Tailwind CSS",
+          "End-to-end delivery",
+        ],
+      },
+    ],
+    callout:
+      "My strongest edge is backend architecture and engineering judgment: building systems other engineers can extend, operate, and trust under pressure.",
+    statLabel: "4+ YEARS · PRODUCTION SYSTEMS",
+  },
+  contact: {
+    sectionNumber: "06",
+    sectionTitle: "CONTACT",
+    headline: "Let's build something that matters.",
+    intro:
+      "Open to senior engineering roles, consulting engagements, and serious product collaborations.",
+    body:
+      "If you are building a product that needs reliable backend systems, clear technical ownership, and engineering decisions that hold up in production, let's talk.",
+    form: {
+      nameLabel: "Name",
+      emailLabel: "Email",
+      subjectLabel: "Subject",
+      messageLabel: "Message",
+      submitLabel: "Send Message",
+      submittingLabel: "Sending...",
+      placeholders: {
+        name: "Your full name",
+        email: "your@email.com",
+        subject: "What are you building?",
+        message: "Tell me about the role, product, or system you want to discuss.",
+      },
+      validation: {
+        nameRequired: "Please enter your name.",
+        emailInvalid: "Please enter a valid email address.",
+        subjectRequired: "Please enter a subject.",
+        messageRequired: "Please enter a message.",
+        messageMinLength: "Message must be at least 10 characters.",
+      },
+      success: "Message received. I'll get back to you as soon as possible.",
+      securityLoading: "Securing form...",
+      secured: "Form secured",
+      blocked: "Temporarily blocked",
+    },
+  },
+  footer: {
+    strapline: "Senior Backend Engineer · alptalha.dev",
+    copyright: "All rights reserved.",
+  },
+  notFound: {
+    eyebrow: "ERROR 404",
+    title: "Route not found.",
+    description:
+      "The page you're looking for doesn't exist or has moved. At least the failure is handled cleanly.",
+    primaryCta: "Back to Portfolio",
+    secondaryCta: "Go Back",
+  },
+};

--- a/src/lib/content/portfolio/es.ts
+++ b/src/lib/content/portfolio/es.ts
@@ -1,0 +1,275 @@
+import type { PortfolioContent } from "@/types/portfolio";
+
+export const portfolioContentEs: PortfolioContent = {
+  locale: "es",
+  metadata: {
+    title: "Alp Talha Yazar | Senior Backend Engineer",
+    description:
+      "Senior Backend Engineer que construye sistemas empresariales fiables, APIs y plataformas distribuidas para entornos reales de producción.",
+  },
+  nav: {
+    homeLabel: "ATY",
+    items: [
+      { label: "Proyectos", href: "#projects" },
+      { label: "Experiencia", href: "#experience" },
+      { label: "Sobre mí", href: "#about" },
+      { label: "Contacto", href: "#contact" },
+    ],
+    languageLabel: "Idioma",
+    letsTalkLabel: "Hablemos",
+    closeMenuLabel: "Cerrar navegación",
+    openMenuLabel: "Abrir navegación",
+  },
+  hero: {
+    eyebrow: "SENIOR BACKEND ENGINEER",
+    availability: "DISPONIBLE PARA TRABAJO REMOTO",
+    headline: "Construyo sistemas backend que siguen siendo fiables bajo carga real.",
+    supportingText:
+      "Arquitectura, fiabilidad y escala para software empresarial en producción.",
+    primaryCta: "Ver trabajo seleccionado",
+    secondaryCta: "Iniciar conversación",
+    techTags: [
+      ".NET 9",
+      "C#",
+      "ASP.NET Core",
+      "Microservices",
+      "PostgreSQL",
+      "Redis",
+      "Docker",
+      "Kubernetes",
+    ],
+  },
+  about: {
+    sectionNumber: "02",
+    sectionTitle: "SOBRE MÍ",
+    lead: "Un ingeniero de software que construye sistemas backend que resisten en condiciones reales.",
+    paragraphs: [
+      "Trabajo en las capas de un producto que deben mantenerse sólidas cuando el sistema se exige: APIs, límites entre servicios, flujos de datos, colas, despliegues y las decisiones operativas alrededor de todo eso.",
+      "Mi mejor trabajo ha estado en software empresarial B2B y B2G, infraestructura de IA y sistemas de plataforma donde la corrección, la mantenibilidad y la observabilidad importan tanto como entregar funcionalidades.",
+      "Construyo principalmente con .NET y C#, me muevo con soltura en PostgreSQL, Redis, Docker y Kubernetes, y puedo recorrer el stack cuando el producto necesita a alguien que entienda tanto la entrega como la arquitectura.",
+    ],
+    statusPill: "Basado en Turquía · Abierto a oportunidades remotas",
+  },
+  experience: {
+    sectionNumber: "03",
+    sectionTitle: "EXPERIENCIA",
+    intro:
+      "Más de cuatro años construyendo sistemas que tienen que seguir operando bajo restricciones reales de producción.",
+    items: [
+      {
+        number: "01",
+        company: "Dias (Atlastek)",
+        role: "Backend Developer",
+        period: "2023 - Actualidad",
+        location: "Turquía",
+        description:
+          "Desarrollo sistemas B2G de seguimiento y gestión para entornos regulados. Enfoque en fiabilidad de servicios, flujos de datos intensivos y visibilidad operativa sobre una plataforma distribuida en producción.",
+        tags: [
+          ".NET 9",
+          "C#",
+          "Entity Framework Core",
+          "PostgreSQL",
+          "Redis",
+          "RabbitMQ",
+          "Docker",
+          "Kubernetes",
+        ],
+      },
+      {
+        number: "02",
+        company: "Wiro AI",
+        role: "Software Engineer",
+        period: "Jul 2023 - Ago 2024",
+        location: "Estambul, Turquía",
+        description:
+          "Construí infraestructura de IA/ML con workers GPU en Linux, interfaces de prueba de modelos, distribución de peticiones LLM, APIs y monitorización en vivo. Trabajé muy cerca de la orquestación y la visibilidad operativa.",
+        tags: [
+          ".NET 8",
+          "Blazor",
+          "PostgreSQL",
+          "Redis",
+          "Docker",
+          "Linux",
+          "SignalR",
+          "Tailwind CSS",
+        ],
+      },
+      {
+        number: "03",
+        company: "Jetlink",
+        role: "Full Stack Developer",
+        period: "2021 - 2022",
+        location: "Turquía",
+        description:
+          "Entregué una plataforma de chatbot de múltiples proyectos con CMS, APIs REST, UI para usuario final, reporting e integraciones. Lideré trabajo de modernización legacy y entregas tanto backend como de cara al producto.",
+        tags: [
+          ".NET 6",
+          "ASP.NET MVC",
+          "MongoDB",
+          "WebSockets",
+          "React",
+          "TypeScript",
+          "IIS",
+        ],
+      },
+    ],
+  },
+  projects: {
+    sectionNumber: "04",
+    sectionTitle: "TRABAJO SELECCIONADO",
+    intro: "Sistemas construidos en producción, no en demos.",
+    items: [
+      {
+        number: "01",
+        name: "Enterprise Management Platform",
+        company: "Dias (Atlastek)",
+        description:
+          "Monitorización y seguimiento operativo en tiempo real para clientes empresariales de sectores regulados, construido alrededor de alta disponibilidad, grandes flujos de eventos y coordinación entre servicios.",
+        themes: [
+          "Fiabilidad operativa",
+          "Monitorización en tiempo real",
+          "Flujos de datos a gran escala",
+        ],
+        tags: [".NET 9", "PostgreSQL", "Redis", "RabbitMQ", "Docker", "Kubernetes"],
+      },
+      {
+        number: "02",
+        name: "Enterprise Asset Tracking System",
+        company: "Dias (Atlastek)",
+        description:
+          "Sistema multi-tenant de seguimiento de activos y reporting para entornos con alto nivel de cumplimiento, donde la auditabilidad, la claridad del dominio y los contratos backend estables fueron claves.",
+        themes: [
+          "Entornos regulados",
+          "Arquitectura multi-tenant",
+          "Reporting y cumplimiento",
+        ],
+        tags: [".NET 9", "C#", "Entity Framework Core", "PostgreSQL", "Docker"],
+      },
+      {
+        number: "03",
+        name: "Wiro AI ML Infrastructure Platform",
+        company: "Wiro AI",
+        description:
+          "Plataforma de infraestructura para operaciones IA/ML: workers GPU, distribución de peticiones, flujos de prueba de modelos y monitorización en vivo, diseñada para hacer los sistemas internos más observables y operables.",
+        themes: [
+          "Orquestación de workers GPU",
+          "Distribución de peticiones",
+          "Visibilidad del sistema",
+        ],
+        tags: [".NET 8", "Redis", "PostgreSQL", "Docker", "Linux", "SignalR"],
+      },
+      {
+        number: "04",
+        name: "Jetlink Multi-Project Chatbot Platform",
+        company: "Jetlink",
+        description:
+          "Plataforma full-stack de chatbot con CMS, APIs, reporting, integraciones y UI de usuario final. Incluyó modernización de .NET legacy y flujos de comunicación en tiempo real.",
+        themes: [
+          "Arquitectura de plataforma",
+          "Modernización legacy",
+          "Sistemas con muchas integraciones",
+        ],
+        tags: [".NET 6", "MongoDB", "WebSockets", "React", "TypeScript", "IIS"],
+      },
+    ],
+  },
+  capabilities: {
+    sectionNumber: "05",
+    sectionTitle: "CAPACIDADES",
+    groups: [
+      {
+        category: "Backend",
+        items: [
+          ".NET / C#",
+          "ASP.NET Core",
+          "Diseño de APIs REST",
+          "Microservices",
+          "Entity Framework Core",
+          "SignalR",
+        ],
+      },
+      {
+        category: "Datos",
+        items: [
+          "PostgreSQL",
+          "Redis",
+          "MongoDB",
+          "SQL Server",
+          "Modelado de datos",
+          "Rendimiento de consultas",
+        ],
+      },
+      {
+        category: "Plataforma",
+        items: [
+          "Docker",
+          "Kubernetes",
+          "Linux",
+          "Pensamiento CI/CD",
+          "Preparación operativa",
+          "Gestión de entornos",
+        ],
+      },
+      {
+        category: "Fluidez Full Stack",
+        items: [
+          "React",
+          "Next.js",
+          "TypeScript",
+          "Blazor",
+          "Tailwind CSS",
+          "Entrega end-to-end",
+        ],
+      },
+    ],
+    callout:
+      "Mi punto más fuerte es la arquitectura backend y el criterio de ingeniería: construir sistemas que otros ingenieros puedan ampliar, operar y en los que puedan confiar bajo presión.",
+    statLabel: "4+ AÑOS · SISTEMAS EN PRODUCCIÓN",
+  },
+  contact: {
+    sectionNumber: "06",
+    sectionTitle: "CONTACTO",
+    headline: "Construyamos algo que importe.",
+    intro:
+      "Disponible para roles senior, consultoría y colaboraciones serias de producto.",
+    body:
+      "Si estás construyendo un producto que necesita sistemas backend fiables, propiedad técnica clara y decisiones de ingeniería que aguanten en producción, hablemos.",
+    form: {
+      nameLabel: "Nombre",
+      emailLabel: "Correo",
+      subjectLabel: "Asunto",
+      messageLabel: "Mensaje",
+      submitLabel: "Enviar mensaje",
+      submittingLabel: "Enviando...",
+      placeholders: {
+        name: "Tu nombre completo",
+        email: "tu@email.com",
+        subject: "¿De qué se trata?",
+        message: "Cuéntame sobre el rol, producto o sistema que quieres discutir.",
+      },
+      validation: {
+        nameRequired: "Introduce tu nombre.",
+        emailInvalid: "Introduce un correo válido.",
+        subjectRequired: "Introduce un asunto.",
+        messageRequired: "Introduce un mensaje.",
+        messageMinLength: "El mensaje debe tener al menos 10 caracteres.",
+      },
+      success: "Mensaje recibido. Te responderé lo antes posible.",
+      securityLoading: "Protegiendo formulario...",
+      secured: "Formulario protegido",
+      blocked: "Bloqueado temporalmente",
+    },
+  },
+  footer: {
+    strapline: "Senior Backend Engineer · alptalha.dev",
+    copyright: "Todos los derechos reservados.",
+  },
+  notFound: {
+    eyebrow: "ERROR 404",
+    title: "Ruta no encontrada.",
+    description:
+      "La página que buscas no existe o se ha movido. Al menos el fallo está manejado con limpieza.",
+    primaryCta: "Volver al portafolio",
+    secondaryCta: "Volver",
+  },
+};

--- a/src/lib/content/portfolio/index.test.ts
+++ b/src/lib/content/portfolio/index.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import { getPortfolioContent } from ".";
+
+describe("portfolio content", () => {
+  it("returns the approved english hero copy", () => {
+    const content = getPortfolioContent("en");
+
+    expect(content.hero.headline).toBe(
+      "I build backend systems that stay reliable under real load."
+    );
+    expect(content.hero.supportingText).toBe(
+      "Architecture, reliability, and scale for enterprise software in production."
+    );
+  });
+
+  it("returns translated content for turkish routes", () => {
+    const content = getPortfolioContent("tr");
+
+    expect(content.nav.items[0].label).toBe("Projeler");
+    expect(content.contact.headline).toBe(
+      "Önemli işler üretelim."
+    );
+  });
+
+  it("returns translated content for spanish routes", () => {
+    const content = getPortfolioContent("es");
+
+    expect(content.nav.items[1].label).toBe("Experiencia");
+    expect(content.notFound.title).toBe("Ruta no encontrada.");
+  });
+});

--- a/src/lib/content/portfolio/index.ts
+++ b/src/lib/content/portfolio/index.ts
@@ -1,0 +1,22 @@
+import type { PortfolioLocale } from "@/types/portfolio";
+
+import { portfolioContentEn } from "./en";
+import { portfolioContentEs } from "./es";
+import { portfolioContentTr } from "./tr";
+
+const portfolioContentByLocale = {
+  en: portfolioContentEn,
+  tr: portfolioContentTr,
+  es: portfolioContentEs,
+} as const;
+
+export function getPortfolioContent(locale: PortfolioLocale) {
+  return portfolioContentByLocale[locale];
+}
+
+export {
+  portfolioContentByLocale,
+  portfolioContentEn,
+  portfolioContentTr,
+  portfolioContentEs,
+};

--- a/src/lib/content/portfolio/tr.ts
+++ b/src/lib/content/portfolio/tr.ts
@@ -1,0 +1,275 @@
+import type { PortfolioContent } from "@/types/portfolio";
+
+export const portfolioContentTr: PortfolioContent = {
+  locale: "tr",
+  metadata: {
+    title: "Alp Talha Yazar | Senior Backend Engineer",
+    description:
+      "Gerçek production ortamları için güvenilir kurumsal sistemler, API'ler ve dağıtık platformlar geliştiren Senior Backend Engineer.",
+  },
+  nav: {
+    homeLabel: "ATY",
+    items: [
+      { label: "Projeler", href: "#projects" },
+      { label: "Deneyim", href: "#experience" },
+      { label: "Hakkımda", href: "#about" },
+      { label: "İletişim", href: "#contact" },
+    ],
+    languageLabel: "Dil",
+    letsTalkLabel: "Konuşalım",
+    closeMenuLabel: "Navigasyonu kapat",
+    openMenuLabel: "Navigasyonu aç",
+  },
+  hero: {
+    eyebrow: "SENIOR BACKEND ENGINEER",
+    availability: "REMOTE ROLLER İÇİN UYGUN",
+    headline: "Gerçek yük altında güvenilir kalan backend sistemleri geliştiriyorum.",
+    supportingText:
+      "Production ortamındaki kurumsal yazılımlar için mimari, güvenilirlik ve ölçek.",
+    primaryCta: "Öne Çıkan İşler",
+    secondaryCta: "İletişime Geç",
+    techTags: [
+      ".NET 9",
+      "C#",
+      "ASP.NET Core",
+      "Microservices",
+      "PostgreSQL",
+      "Redis",
+      "Docker",
+      "Kubernetes",
+    ],
+  },
+  about: {
+    sectionNumber: "02",
+    sectionTitle: "HAKKIMDA",
+    lead: "Gerçek koşullarda ayakta kalan backend sistemleri geliştiren bir yazılım mühendisi.",
+    paragraphs: [
+      "Bir ürün yoğunlaştığında sağlam kalması gereken katmanlarda çalışıyorum: API'ler, servis sınırları, veri akışları, kuyruklar, deployment süreçleri ve bunların etrafındaki operasyonel kararlar.",
+      "En güçlü işlerimi enterprise B2B ve B2G yazılımlarda, AI altyapısında ve doğruluk, sürdürülebilirlik ve gözlemlenebilirlik isteyen platform tarzı sistemlerde ürettim.",
+      "Ağırlıklı olarak .NET ve C# ile geliştiriyorum; PostgreSQL, Redis, Docker ve Kubernetes tarafında rahat çalışıyorum; ürün gerektiğinde teslimat ile mimariyi birlikte düşünebilen biri olarak stack boyunca ilerleyebiliyorum.",
+    ],
+    statusPill: "Türkiye'de · Remote fırsatlara açık",
+  },
+  experience: {
+    sectionNumber: "03",
+    sectionTitle: "DENEYİM",
+    intro:
+      "Gerçek production kısıtları altında çalışması gereken sistemler geliştirerek geçen 4+ yıl.",
+    items: [
+      {
+        number: "01",
+        company: "Dias (Atlastek)",
+        role: "Backend Developer",
+        period: "2023 - Günümüz",
+        location: "Türkiye",
+        description:
+          "Regüle ortamlara yönelik enterprise seviyede B2G takip ve yönetim sistemleri geliştiriyorum. Dağıtık production stack üzerinde servis güvenilirliği, yoğun veri akışları ve operasyonel görünürlük tarafına odaklanıyorum.",
+        tags: [
+          ".NET 9",
+          "C#",
+          "Entity Framework Core",
+          "PostgreSQL",
+          "Redis",
+          "RabbitMQ",
+          "Docker",
+          "Kubernetes",
+        ],
+      },
+      {
+        number: "02",
+        company: "Wiro AI",
+        role: "Software Engineer",
+        period: "Tem 2023 - Ağu 2024",
+        location: "İstanbul, Türkiye",
+        description:
+          "Linux GPU worker'ları, model test arayüzleri, LLM request dağıtımı, API'ler ve canlı izleme içeren AI/ML altyapıları geliştirdim. Orkestrasyon, iç araçlar ve sistem görünürlüğü tarafında yoğun çalıştım.",
+        tags: [
+          ".NET 8",
+          "Blazor",
+          "PostgreSQL",
+          "Redis",
+          "Docker",
+          "Linux",
+          "SignalR",
+          "Tailwind CSS",
+        ],
+      },
+      {
+        number: "03",
+        company: "Jetlink",
+        role: "Full Stack Developer",
+        period: "2021 - 2022",
+        location: "Türkiye",
+        description:
+          "CMS, REST API, son kullanıcı arayüzü, raporlama ve entegrasyonlardan oluşan çok projeli chatbot platformunda çalıştım. Legacy'den moderne geçişi yönettim ve hem backend ağırlıklı hem ürün yüzeyine yakın alanlarda teslimat yaptım.",
+        tags: [
+          ".NET 6",
+          "ASP.NET MVC",
+          "MongoDB",
+          "WebSockets",
+          "React",
+          "TypeScript",
+          "IIS",
+        ],
+      },
+    ],
+  },
+  projects: {
+    sectionNumber: "04",
+    sectionTitle: "SEÇİLMİŞ İŞLER",
+    intro: "Demo için değil, production için kurulmuş sistemler.",
+    items: [
+      {
+        number: "01",
+        name: "Enterprise Management Platform",
+        company: "Dias (Atlastek)",
+        description:
+          "Regüle sektörlerde enterprise müşteriler için gerçek zamanlı operasyon izleme ve takip sistemi. Yüksek uptime, yoğun event akışları ve servisler arası koordinasyon etrafında şekillendi.",
+        themes: [
+          "Operasyonel güvenilirlik",
+          "Gerçek zamanlı izleme",
+          "Yüksek hacimli veri akışı",
+        ],
+        tags: [".NET 9", "PostgreSQL", "Redis", "RabbitMQ", "Docker", "Kubernetes"],
+      },
+      {
+        number: "02",
+        name: "Enterprise Asset Tracking System",
+        company: "Dias (Atlastek)",
+        description:
+          "Compliance yoğun ortamlarda çalışan multi-tenant varlık takip ve raporlama sistemi. Audit edilebilirlik, domain netliği ve stabil backend sözleşmeleri kritik rol oynadı.",
+        themes: [
+          "Regüle ortamlar",
+          "Multi-tenant mimari",
+          "Raporlama ve uyumluluk",
+        ],
+        tags: [".NET 9", "C#", "Entity Framework Core", "PostgreSQL", "Docker"],
+      },
+      {
+        number: "03",
+        name: "Wiro AI ML Infrastructure Platform",
+        company: "Wiro AI",
+        description:
+          "AI/ML operasyonları için GPU worker'lar, request dağıtımı, model test akışları ve canlı izleme içeren altyapı platformu. İç sistemleri daha gözlemlenebilir ve işletilebilir hale getirmek için kuruldu.",
+        themes: [
+          "GPU worker orkestrasyonu",
+          "Request dağıtımı",
+          "Sistem görünürlüğü",
+        ],
+        tags: [".NET 8", "Redis", "PostgreSQL", "Docker", "Linux", "SignalR"],
+      },
+      {
+        number: "04",
+        name: "Jetlink Multi-Project Chatbot Platform",
+        company: "Jetlink",
+        description:
+          "CMS, API, raporlama, entegrasyonlar ve son kullanıcı arayüzünü kapsayan full-stack chatbot platformu. Legacy .NET modernizasyonu ve gerçek zamanlı iletişim akışlarını da içerdi.",
+        themes: [
+          "Platform mimarisi",
+          "Legacy modernizasyonu",
+          "Entegrasyon yoğun sistemler",
+        ],
+        tags: [".NET 6", "MongoDB", "WebSockets", "React", "TypeScript", "IIS"],
+      },
+    ],
+  },
+  capabilities: {
+    sectionNumber: "05",
+    sectionTitle: "YETENEKLER",
+    groups: [
+      {
+        category: "Backend",
+        items: [
+          ".NET / C#",
+          "ASP.NET Core",
+          "REST API tasarımı",
+          "Microservices",
+          "Entity Framework Core",
+          "SignalR",
+        ],
+      },
+      {
+        category: "Veri",
+        items: [
+          "PostgreSQL",
+          "Redis",
+          "MongoDB",
+          "SQL Server",
+          "Veri modelleme",
+          "Query performansı",
+        ],
+      },
+      {
+        category: "Platform",
+        items: [
+          "Docker",
+          "Kubernetes",
+          "Linux",
+          "CI/CD yaklaşımı",
+          "Operasyonel hazırlık",
+          "Environment yönetimi",
+        ],
+      },
+      {
+        category: "Full Stack Yetkinliği",
+        items: [
+          "React",
+          "Next.js",
+          "TypeScript",
+          "Blazor",
+          "Tailwind CSS",
+          "Uçtan uca teslimat",
+        ],
+      },
+    ],
+    callout:
+      "En güçlü tarafım backend mimarisi ve mühendislik muhakemesi: başka mühendislerin rahatça geliştirebildiği, işletebildiği ve baskı altında güvenebildiği sistemler kurmak.",
+    statLabel: "4+ YIL · PRODUCTION SİSTEMLER",
+  },
+  contact: {
+    sectionNumber: "06",
+    sectionTitle: "İLETİŞİM",
+    headline: "Önemli işler üretelim.",
+    intro:
+      "Senior roller, danışmanlık işleri ve ciddi ürün işbirlikleri için açığım.",
+    body:
+      "Güvenilir backend sistemlerine, net teknik sahipliğe ve production'da ayakta kalan mühendislik kararlarına ihtiyacınız varsa konuşalım.",
+    form: {
+      nameLabel: "İsim",
+      emailLabel: "E-posta",
+      subjectLabel: "Konu",
+      messageLabel: "Mesaj",
+      submitLabel: "Mesaj Gönder",
+      submittingLabel: "Gönderiliyor...",
+      placeholders: {
+        name: "Adınız soyadınız",
+        email: "eposta@ornek.com",
+        subject: "Ne üzerine konuşalım?",
+        message: "Rolü, ürünü veya sistemi kısaca anlatın.",
+      },
+      validation: {
+        nameRequired: "Lütfen isminizi girin.",
+        emailInvalid: "Geçerli bir e-posta adresi girin.",
+        subjectRequired: "Lütfen konu girin.",
+        messageRequired: "Lütfen mesaj girin.",
+        messageMinLength: "Mesaj en az 10 karakter olmalı.",
+      },
+      success: "Mesaj alındı. En kısa sürede dönüş yapacağım.",
+      securityLoading: "Form güvenliği hazırlanıyor...",
+      secured: "Form güvenli",
+      blocked: "Geçici olarak engellendi",
+    },
+  },
+  footer: {
+    strapline: "Senior Backend Engineer · alptalha.dev",
+    copyright: "Tüm hakları saklıdır.",
+  },
+  notFound: {
+    eyebrow: "HATA 404",
+    title: "Rota bulunamadı.",
+    description:
+      "Aradığınız sayfa yok veya taşınmış. En azından hata temiz şekilde ele alınıyor.",
+    primaryCta: "Portföye Dön",
+    secondaryCta: "Geri Dön",
+  },
+};

--- a/src/lib/csp.test.ts
+++ b/src/lib/csp.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import { buildCSPHeader } from "./csp";
+
+describe("buildCSPHeader", () => {
+  it("allows inline styles required by motion and font runtime", () => {
+    const header = buildCSPHeader({ nonce: "test-nonce", isDevelopment: false });
+
+    expect(header).toContain("style-src 'self' 'unsafe-inline' fonts.googleapis.com");
+    expect(header).toContain("style-src-attr 'unsafe-inline'");
+  });
+
+  it("keeps unsafe-eval limited to development", () => {
+    const developmentHeader = buildCSPHeader({
+      nonce: "dev-nonce",
+      isDevelopment: true,
+    });
+    const productionHeader = buildCSPHeader({
+      nonce: "prod-nonce",
+      isDevelopment: false,
+    });
+
+    expect(developmentHeader).toContain(
+      "script-src 'self' 'nonce-dev-nonce' 'strict-dynamic' 'unsafe-eval'"
+    );
+    expect(productionHeader).not.toContain("'unsafe-eval'");
+  });
+});

--- a/src/lib/csp.ts
+++ b/src/lib/csp.ts
@@ -1,0 +1,40 @@
+interface BuildCSPHeaderOptions {
+  nonce: string;
+  isDevelopment?: boolean;
+}
+
+export function buildCSPHeader({
+  nonce,
+  isDevelopment = process.env.NODE_ENV !== "production",
+}: BuildCSPHeaderOptions): string {
+  const scriptSources = [
+    "'self'",
+    `'nonce-${nonce}'`,
+    "'strict-dynamic'",
+    "https://www.googletagmanager.com",
+    "https://www.google-analytics.com",
+  ];
+
+  if (isDevelopment) {
+    scriptSources.splice(3, 0, "'unsafe-eval'");
+  }
+
+  const cspDirectives = [
+    "default-src 'self'",
+    `script-src ${scriptSources.join(" ")}`,
+    // Framer Motion, Next font styles, and the dev overlay rely on inline style tags/attributes.
+    "style-src 'self' 'unsafe-inline' fonts.googleapis.com",
+    "style-src-attr 'unsafe-inline'",
+    "font-src 'self' fonts.gstatic.com",
+    "img-src 'self' data: blob: https:",
+    "media-src 'self'",
+    "object-src 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "frame-ancestors 'none'",
+    "connect-src 'self' https://www.google-analytics.com https://analytics.google.com https://region1.google-analytics.com",
+    "upgrade-insecure-requests",
+  ];
+
+  return cspDirectives.join("; ");
+}

--- a/src/lib/i18n/routing.test.ts
+++ b/src/lib/i18n/routing.test.ts
@@ -12,11 +12,11 @@ describe("i18n routing helpers", () => {
     it("returns true for supported locales", () => {
       expect(isSupportedLocale("en")).toBe(true);
       expect(isSupportedLocale("tr")).toBe(true);
-      expect(isSupportedLocale("es")).toBe(true);
     });
 
     it("returns false for unsupported locales", () => {
       expect(isSupportedLocale("de")).toBe(false);
+      expect(isSupportedLocale("es")).toBe(false);
       expect(isSupportedLocale("")).toBe(false);
     });
   });
@@ -29,11 +29,11 @@ describe("i18n routing helpers", () => {
     it("reads prefixed locale routes", () => {
       expect(getLocaleFromPathname("/tr")).toBe("tr");
       expect(getLocaleFromPathname("/tr/projects")).toBe("tr");
-      expect(getLocaleFromPathname("/es/contact")).toBe("es");
     });
 
     it("falls back to english for unknown prefixes", () => {
       expect(getLocaleFromPathname("/de")).toBe("en");
+      expect(getLocaleFromPathname("/es/contact")).toBe("en");
       expect(getLocaleFromPathname("/work")).toBe("en");
     });
   });
@@ -41,8 +41,8 @@ describe("i18n routing helpers", () => {
   describe("stripLocaleFromPathname", () => {
     it("removes locale prefixes while preserving root semantics", () => {
       expect(stripLocaleFromPathname("/tr")).toBe("/");
-      expect(stripLocaleFromPathname("/es")).toBe("/");
       expect(stripLocaleFromPathname("/tr/projects")).toBe("/projects");
+      expect(stripLocaleFromPathname("/es")).toBe("/es");
       expect(stripLocaleFromPathname("/about")).toBe("/about");
     });
   });
@@ -52,22 +52,21 @@ describe("i18n routing helpers", () => {
       expect(buildLocalizedHref("en", "/")).toBe("/");
       expect(buildLocalizedHref("en", "/tr#contact")).toBe("/#contact");
       expect(buildLocalizedHref("en", "/es/projects?tab=selected")).toBe(
-        "/projects?tab=selected"
+        "/es/projects?tab=selected"
       );
     });
 
     it("adds locale prefixes for non-default locales", () => {
       expect(buildLocalizedHref("tr", "/")).toBe("/tr");
       expect(buildLocalizedHref("tr", "/#contact")).toBe("/tr#contact");
-      expect(buildLocalizedHref("es", "/projects")).toBe("/es/projects");
     });
 
     it("preserves query strings and hash fragments", () => {
       expect(buildLocalizedHref("tr", "/projects?tab=selected#contact")).toBe(
         "/tr/projects?tab=selected#contact"
       );
-      expect(buildLocalizedHref("es", "/tr?view=compact#hero")).toBe(
-        "/es?view=compact#hero"
+      expect(buildLocalizedHref("en", "/tr?view=compact#hero")).toBe(
+        "/?view=compact#hero"
       );
     });
   });

--- a/src/lib/i18n/routing.test.ts
+++ b/src/lib/i18n/routing.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildLocalizedHref,
+  getLocaleFromPathname,
+  isSupportedLocale,
+  stripLocaleFromPathname,
+} from "./routing";
+
+describe("i18n routing helpers", () => {
+  describe("isSupportedLocale", () => {
+    it("returns true for supported locales", () => {
+      expect(isSupportedLocale("en")).toBe(true);
+      expect(isSupportedLocale("tr")).toBe(true);
+      expect(isSupportedLocale("es")).toBe(true);
+    });
+
+    it("returns false for unsupported locales", () => {
+      expect(isSupportedLocale("de")).toBe(false);
+      expect(isSupportedLocale("")).toBe(false);
+    });
+  });
+
+  describe("getLocaleFromPathname", () => {
+    it("uses english for the root route", () => {
+      expect(getLocaleFromPathname("/")).toBe("en");
+    });
+
+    it("reads prefixed locale routes", () => {
+      expect(getLocaleFromPathname("/tr")).toBe("tr");
+      expect(getLocaleFromPathname("/tr/projects")).toBe("tr");
+      expect(getLocaleFromPathname("/es/contact")).toBe("es");
+    });
+
+    it("falls back to english for unknown prefixes", () => {
+      expect(getLocaleFromPathname("/de")).toBe("en");
+      expect(getLocaleFromPathname("/work")).toBe("en");
+    });
+  });
+
+  describe("stripLocaleFromPathname", () => {
+    it("removes locale prefixes while preserving root semantics", () => {
+      expect(stripLocaleFromPathname("/tr")).toBe("/");
+      expect(stripLocaleFromPathname("/es")).toBe("/");
+      expect(stripLocaleFromPathname("/tr/projects")).toBe("/projects");
+      expect(stripLocaleFromPathname("/about")).toBe("/about");
+    });
+  });
+
+  describe("buildLocalizedHref", () => {
+    it("builds english hrefs without a prefix", () => {
+      expect(buildLocalizedHref("en", "/")).toBe("/");
+      expect(buildLocalizedHref("en", "/tr#contact")).toBe("/#contact");
+      expect(buildLocalizedHref("en", "/es/projects?tab=selected")).toBe(
+        "/projects?tab=selected"
+      );
+    });
+
+    it("adds locale prefixes for non-default locales", () => {
+      expect(buildLocalizedHref("tr", "/")).toBe("/tr");
+      expect(buildLocalizedHref("tr", "/#contact")).toBe("/tr#contact");
+      expect(buildLocalizedHref("es", "/projects")).toBe("/es/projects");
+    });
+
+    it("preserves query strings and hash fragments", () => {
+      expect(buildLocalizedHref("tr", "/projects?tab=selected#contact")).toBe(
+        "/tr/projects?tab=selected#contact"
+      );
+      expect(buildLocalizedHref("es", "/tr?view=compact#hero")).toBe(
+        "/es?view=compact#hero"
+      );
+    });
+  });
+});

--- a/src/lib/i18n/routing.ts
+++ b/src/lib/i18n/routing.ts
@@ -1,7 +1,11 @@
 import { defaultLanguage, supportedLanguages, type Language } from "./config";
 
+export const publicPortfolioLocales = supportedLanguages.filter(
+  (locale): locale is Language => locale !== "es"
+) as readonly Language[];
+
 export function isSupportedLocale(value: string): value is Language {
-  return supportedLanguages.includes(value as Language);
+  return publicPortfolioLocales.includes(value as Language);
 }
 
 export function getLocaleFromPathname(pathname: string): Language {

--- a/src/lib/i18n/routing.ts
+++ b/src/lib/i18n/routing.ts
@@ -1,0 +1,40 @@
+import { defaultLanguage, supportedLanguages, type Language } from "./config";
+
+export function isSupportedLocale(value: string): value is Language {
+  return supportedLanguages.includes(value as Language);
+}
+
+export function getLocaleFromPathname(pathname: string): Language {
+  const [, maybeLocale] = pathname.split("/");
+  return maybeLocale && isSupportedLocale(maybeLocale)
+    ? maybeLocale
+    : defaultLanguage;
+}
+
+export function stripLocaleFromPathname(pathname: string): string {
+  const locale = getLocaleFromPathname(pathname);
+
+  if (locale === defaultLanguage) {
+    return pathname || "/";
+  }
+
+  const stripped = pathname.replace(`/${locale}`, "") || "/";
+  return stripped.startsWith("/") ? stripped : `/${stripped}`;
+}
+
+export function buildLocalizedHref(
+  locale: Language,
+  currentHref: string
+): string {
+  const url = new URL(currentHref, "https://www.alptalha.dev");
+  const pathname = stripLocaleFromPathname(url.pathname);
+
+  const localizedPathname =
+    locale === defaultLanguage
+      ? pathname
+      : pathname === "/"
+      ? `/${locale}`
+      : `/${locale}${pathname}`;
+
+  return `${localizedPathname}${url.search}${url.hash}`;
+}

--- a/src/lib/seo/portfolio-metadata.test.ts
+++ b/src/lib/seo/portfolio-metadata.test.ts
@@ -10,7 +10,6 @@ describe("portfolio metadata", () => {
     expect(metadata.alternates?.languages).toEqual({
       en: "https://www.alptalha.dev/",
       tr: "https://www.alptalha.dev/tr/",
-      es: "https://www.alptalha.dev/es/",
       "x-default": "https://www.alptalha.dev/",
     });
   });

--- a/src/lib/seo/portfolio-metadata.test.ts
+++ b/src/lib/seo/portfolio-metadata.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import { buildPortfolioMetadata } from "./portfolio-metadata";
+
+describe("portfolio metadata", () => {
+  it("builds english canonical metadata for the root route", () => {
+    const metadata = buildPortfolioMetadata("en");
+
+    expect(metadata.alternates?.canonical).toBe("https://www.alptalha.dev/");
+    expect(metadata.alternates?.languages).toEqual({
+      en: "https://www.alptalha.dev/",
+      tr: "https://www.alptalha.dev/tr/",
+      es: "https://www.alptalha.dev/es/",
+      "x-default": "https://www.alptalha.dev/",
+    });
+  });
+
+  it("builds localized canonical metadata for prefixed routes", () => {
+    const metadata = buildPortfolioMetadata("tr");
+
+    expect(metadata.alternates?.canonical).toBe("https://www.alptalha.dev/tr/");
+    expect(metadata.openGraph?.locale).toBe("tr_TR");
+  });
+});

--- a/src/lib/seo/portfolio-metadata.test.ts
+++ b/src/lib/seo/portfolio-metadata.test.ts
@@ -12,6 +12,23 @@ describe("portfolio metadata", () => {
       tr: "https://www.alptalha.dev/tr/",
       "x-default": "https://www.alptalha.dev/",
     });
+    expect(metadata.openGraph?.images).toEqual([
+      {
+        url: "https://www.alptalha.dev/opengraph-image",
+        width: 1200,
+        height: 630,
+        alt: "Alp Talha Yazar portfolio preview",
+      },
+    ]);
+    expect(metadata.twitter).toMatchObject({
+      card: "summary_large_image",
+      images: [
+        {
+          url: "https://www.alptalha.dev/twitter-image",
+          alt: "Alp Talha Yazar portfolio preview",
+        },
+      ],
+    });
   });
 
   it("builds localized canonical metadata for prefixed routes", () => {
@@ -19,5 +36,22 @@ describe("portfolio metadata", () => {
 
     expect(metadata.alternates?.canonical).toBe("https://www.alptalha.dev/tr/");
     expect(metadata.openGraph?.locale).toBe("tr_TR");
+    expect(metadata.openGraph?.images).toEqual([
+      {
+        url: "https://www.alptalha.dev/tr/opengraph-image",
+        width: 1200,
+        height: 630,
+        alt: "Alp Talha Yazar portfolyo onizlemesi",
+      },
+    ]);
+    expect(metadata.twitter).toMatchObject({
+      card: "summary_large_image",
+      images: [
+        {
+          url: "https://www.alptalha.dev/tr/twitter-image",
+          alt: "Alp Talha Yazar portfolyo onizlemesi",
+        },
+      ],
+    });
   });
 });

--- a/src/lib/seo/portfolio-metadata.ts
+++ b/src/lib/seo/portfolio-metadata.ts
@@ -1,0 +1,50 @@
+import type { Metadata } from "next";
+
+import { siteConfig } from "@/lib/site";
+import type { PortfolioLocale } from "@/types/portfolio";
+
+import { getPortfolioContent } from "../content/portfolio";
+
+const localeToOpenGraph = {
+  en: "en_US",
+  tr: "tr_TR",
+  es: "es_ES",
+} as const;
+
+function getCanonicalUrl(locale: PortfolioLocale): string {
+  return locale === "en" ? `${siteConfig.baseUrl}/` : `${siteConfig.baseUrl}/${locale}/`;
+}
+
+export function buildPortfolioMetadata(locale: PortfolioLocale): Metadata {
+  const content = getPortfolioContent(locale);
+
+  return {
+    title: content.metadata.title,
+    description: content.metadata.description,
+    alternates: {
+      canonical: getCanonicalUrl(locale),
+      languages: {
+        en: `${siteConfig.baseUrl}/`,
+        tr: `${siteConfig.baseUrl}/tr/`,
+        es: `${siteConfig.baseUrl}/es/`,
+        "x-default": `${siteConfig.baseUrl}/`,
+      },
+    },
+    openGraph: {
+      title: content.metadata.title,
+      description: content.metadata.description,
+      type: "website",
+      url: getCanonicalUrl(locale),
+      siteName: siteConfig.fullName,
+      locale: localeToOpenGraph[locale],
+      alternateLocale: Object.values(localeToOpenGraph).filter(
+        (value) => value !== localeToOpenGraph[locale]
+      ),
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: content.metadata.title,
+      description: content.metadata.description,
+    },
+  };
+}

--- a/src/lib/seo/portfolio-metadata.ts
+++ b/src/lib/seo/portfolio-metadata.ts
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 
+import { publicPortfolioLocales } from "@/lib/i18n/routing";
 import { siteConfig } from "@/lib/site";
 import type { PortfolioLocale } from "@/types/portfolio";
 
@@ -26,7 +27,6 @@ export function buildPortfolioMetadata(locale: PortfolioLocale): Metadata {
       languages: {
         en: `${siteConfig.baseUrl}/`,
         tr: `${siteConfig.baseUrl}/tr/`,
-        es: `${siteConfig.baseUrl}/es/`,
         "x-default": `${siteConfig.baseUrl}/`,
       },
     },
@@ -37,9 +37,9 @@ export function buildPortfolioMetadata(locale: PortfolioLocale): Metadata {
       url: getCanonicalUrl(locale),
       siteName: siteConfig.fullName,
       locale: localeToOpenGraph[locale],
-      alternateLocale: Object.values(localeToOpenGraph).filter(
-        (value) => value !== localeToOpenGraph[locale]
-      ),
+      alternateLocale: publicPortfolioLocales
+        .map((supportedLocale) => localeToOpenGraph[supportedLocale])
+        .filter((value) => value !== localeToOpenGraph[locale]),
     },
     twitter: {
       card: "summary_large_image",

--- a/src/lib/seo/portfolio-metadata.ts
+++ b/src/lib/seo/portfolio-metadata.ts
@@ -5,6 +5,11 @@ import { siteConfig } from "@/lib/site";
 import type { PortfolioLocale } from "@/types/portfolio";
 
 import { getPortfolioContent } from "../content/portfolio";
+import {
+  getSocialPreviewAlt,
+  getSocialPreviewUrl,
+  socialPreviewSize,
+} from "./social-preview";
 
 const localeToOpenGraph = {
   en: "en_US",
@@ -18,6 +23,16 @@ function getCanonicalUrl(locale: PortfolioLocale): string {
 
 export function buildPortfolioMetadata(locale: PortfolioLocale): Metadata {
   const content = getPortfolioContent(locale);
+  const openGraphImage = {
+    url: getSocialPreviewUrl(locale, "opengraph"),
+    width: socialPreviewSize.width,
+    height: socialPreviewSize.height,
+    alt: getSocialPreviewAlt(locale),
+  };
+  const twitterImage = {
+    url: getSocialPreviewUrl(locale, "twitter"),
+    alt: getSocialPreviewAlt(locale),
+  };
 
   return {
     title: content.metadata.title,
@@ -37,6 +52,7 @@ export function buildPortfolioMetadata(locale: PortfolioLocale): Metadata {
       url: getCanonicalUrl(locale),
       siteName: siteConfig.fullName,
       locale: localeToOpenGraph[locale],
+      images: [openGraphImage],
       alternateLocale: publicPortfolioLocales
         .map((supportedLocale) => localeToOpenGraph[supportedLocale])
         .filter((value) => value !== localeToOpenGraph[locale]),
@@ -45,6 +61,7 @@ export function buildPortfolioMetadata(locale: PortfolioLocale): Metadata {
       card: "summary_large_image",
       title: content.metadata.title,
       description: content.metadata.description,
+      images: [twitterImage],
     },
   };
 }

--- a/src/lib/seo/portfolio-metadata.ts
+++ b/src/lib/seo/portfolio-metadata.ts
@@ -17,7 +17,7 @@ const localeToOpenGraph = {
   es: "es_ES",
 } as const;
 
-function getCanonicalUrl(locale: PortfolioLocale): string {
+export function getCanonicalUrl(locale: PortfolioLocale): string {
   return locale === "en" ? `${siteConfig.baseUrl}/` : `${siteConfig.baseUrl}/${locale}/`;
 }
 

--- a/src/lib/seo/social-preview.tsx
+++ b/src/lib/seo/social-preview.tsx
@@ -1,0 +1,232 @@
+import { ImageResponse } from "next/og";
+
+import { getPortfolioContent } from "@/lib/content/portfolio";
+import { siteConfig } from "@/lib/site";
+import type { PortfolioLocale } from "@/types/portfolio";
+
+export const socialPreviewSize = {
+  width: 1200,
+  height: 630,
+} as const;
+
+export const socialPreviewContentType = "image/png";
+
+const socialPreviewAlt: Record<PortfolioLocale, string> = {
+  en: "Alp Talha Yazar portfolio preview",
+  tr: "Alp Talha Yazar portfolyo onizlemesi",
+  es: "Vista previa del portafolio de Alp Talha Yazar",
+};
+
+export function getSocialPreviewAlt(locale: PortfolioLocale) {
+  return socialPreviewAlt[locale];
+}
+
+export function getSocialPreviewPath(
+  locale: PortfolioLocale,
+  kind: "opengraph" | "twitter"
+) {
+  const prefix = locale === "en" ? "" : `/${locale}`;
+  const slug = kind === "opengraph" ? "opengraph-image" : "twitter-image";
+
+  return `${prefix}/${slug}`;
+}
+
+export function getSocialPreviewUrl(
+  locale: PortfolioLocale,
+  kind: "opengraph" | "twitter"
+) {
+  return `${siteConfig.baseUrl}${getSocialPreviewPath(locale, kind)}`;
+}
+
+export function buildSocialPreviewImage(locale: PortfolioLocale) {
+  const content = getPortfolioContent(locale);
+  const previewTags = content.hero.techTags.slice(0, 4);
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          height: "100%",
+          width: "100%",
+          display: "flex",
+          position: "relative",
+          overflow: "hidden",
+          background: "#080808",
+          color: "#f4f1ea",
+          fontFamily: "sans-serif",
+        }}
+      >
+        <div
+          style={{
+            position: "absolute",
+            inset: 0,
+            backgroundImage:
+              "linear-gradient(rgba(198,255,109,0.12) 1px, transparent 1px), linear-gradient(90deg, rgba(198,255,109,0.12) 1px, transparent 1px)",
+            backgroundSize: "40px 40px",
+            opacity: 0.3,
+          }}
+        />
+
+        <div
+          style={{
+            position: "absolute",
+            top: 48,
+            right: 56,
+            height: 180,
+            width: 180,
+            borderRadius: "999px",
+            background:
+              "radial-gradient(circle, rgba(198,255,109,0.24) 0%, rgba(198,255,109,0) 70%)",
+          }}
+        />
+
+        <div
+          style={{
+            position: "relative",
+            display: "flex",
+            flexDirection: "column",
+            justifyContent: "space-between",
+            width: "100%",
+            padding: "56px",
+            border: "1px solid rgba(198,255,109,0.24)",
+            margin: "24px",
+          }}
+        >
+          <div
+            style={{
+              display: "flex",
+              justifyContent: "space-between",
+              alignItems: "center",
+            }}
+          >
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: "14px",
+                fontSize: 20,
+                letterSpacing: "0.28em",
+                color: "#c6ff6d",
+              }}
+            >
+              <div
+                style={{
+                  width: 42,
+                  height: 1,
+                  background: "#c6ff6d",
+                }}
+              />
+              <span>{content.hero.eyebrow}</span>
+            </div>
+            <div
+              style={{
+                display: "flex",
+                padding: "10px 16px",
+                border: "1px solid rgba(244,241,234,0.18)",
+                fontSize: 18,
+                color: "#f4f1ea",
+              }}
+            >
+              {content.hero.availability}
+            </div>
+          </div>
+
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              gap: "18px",
+              maxWidth: "880px",
+            }}
+          >
+            <div
+              style={{
+                display: "flex",
+                fontSize: 28,
+                letterSpacing: "0.24em",
+                color: "#9b9688",
+              }}
+            >
+              {siteConfig.fullName.toUpperCase()}
+            </div>
+            <div
+              style={{
+                display: "flex",
+                fontSize: 68,
+                lineHeight: 1.03,
+                fontWeight: 700,
+                letterSpacing: "-0.05em",
+              }}
+            >
+              {content.hero.headline}
+            </div>
+            <div
+              style={{
+                display: "flex",
+                fontSize: 28,
+                lineHeight: 1.4,
+                color: "#c8c3b6",
+                maxWidth: "820px",
+              }}
+            >
+              {content.hero.supportingText}
+            </div>
+          </div>
+
+          <div
+            style={{
+              display: "flex",
+              justifyContent: "space-between",
+              alignItems: "flex-end",
+              gap: "24px",
+            }}
+          >
+            <div
+              style={{
+                display: "flex",
+                gap: "12px",
+                flexWrap: "wrap",
+                maxWidth: "820px",
+              }}
+            >
+              {previewTags.map((tag) => (
+                <div
+                  key={tag}
+                  style={{
+                    display: "flex",
+                    padding: "12px 18px",
+                    border: "1px solid rgba(244,241,234,0.16)",
+                    background: "rgba(13,13,13,0.72)",
+                    fontSize: 18,
+                    color: "#f4f1ea",
+                  }}
+                >
+                  {tag}
+                </div>
+              ))}
+            </div>
+
+            <div
+              style={{
+                display: "flex",
+                flexDirection: "column",
+                alignItems: "flex-end",
+                gap: "10px",
+                color: "#9b9688",
+                fontSize: 18,
+              }}
+            >
+              <div style={{ display: "flex", color: "#c6ff6d", letterSpacing: "0.18em" }}>
+                PRODUCTION PORTFOLIO
+              </div>
+              <div style={{ display: "flex" }}>
+                {siteConfig.baseUrl.replace(/^https?:\/\//, "")}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    ),
+    socialPreviewSize
+  );
+}

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -1,0 +1,29 @@
+export interface SiteLink {
+  readonly label: string;
+  readonly href: string;
+}
+
+const resolvedBaseUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://www.alptalha.dev";
+
+export const siteConfig = {
+  baseUrl: resolvedBaseUrl.replace(/\/+$/, ""),
+  fullName: process.env.NEXT_PUBLIC_FULL_NAME || "Alp Talha Yazar",
+  email: process.env.NEXT_PUBLIC_CONTACT_EMAIL || "contact@alptalha.dev",
+  location: process.env.NEXT_PUBLIC_CONTACT_LOCATION || "Turkey",
+  phone: process.env.NEXT_PUBLIC_CONTACT_PHONE || "",
+  githubUrl: process.env.NEXT_PUBLIC_GITHUB_URL || "https://github.com/alptalha",
+  linkedInUrl:
+    process.env.NEXT_PUBLIC_LINKEDIN_URL || "https://linkedin.com/in/alptalha",
+} as const;
+
+export const socialLinks: readonly SiteLink[] = [
+  { label: "GitHub", href: siteConfig.githubUrl },
+  { label: "LinkedIn", href: siteConfig.linkedInUrl },
+  { label: "Email", href: `mailto:${siteConfig.email}` },
+];
+
+export const contactDetails: readonly SiteLink[] = [
+  { label: siteConfig.email, href: `mailto:${siteConfig.email}` },
+  { label: siteConfig.linkedInUrl.replace(/^https?:\/\//, ""), href: siteConfig.linkedInUrl },
+  { label: siteConfig.githubUrl.replace(/^https?:\/\//, ""), href: siteConfig.githubUrl },
+];

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -5,6 +5,7 @@ import {
   logSecurityEvent,
   getRateLimitingMethod,
 } from "@/lib/redis-rate-limit";
+import { getLocaleFromPathname } from "@/lib/i18n/routing";
 import type { RateLimitConfig } from "@/types";
 
 // Rate limiting configuration per endpoint
@@ -157,9 +158,13 @@ export async function middleware(request: NextRequest) {
   // Generate nonce for CSP
   const nonce = generateNonce();
 
+  const requestHeaders = new Headers(request.headers);
+  requestHeaders.set("x-locale", getLocaleFromPathname(pathname));
+  requestHeaders.set("x-pathname", pathname);
+
   const response = NextResponse.next({
     request: {
-      headers: new Headers(request.headers),
+      headers: requestHeaders,
     },
   });
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -5,6 +5,7 @@ import {
   logSecurityEvent,
   getRateLimitingMethod,
 } from "@/lib/redis-rate-limit";
+import { buildCSPHeader } from "@/lib/csp";
 import { getLocaleFromPathname } from "@/lib/i18n/routing";
 import type { RateLimitConfig } from "@/types";
 
@@ -112,32 +113,6 @@ async function applyRateLimit(
 }
 
 /**
- * Build Content Security Policy header with nonce for inline scripts/styles
- */
-function buildCSPHeader(nonce: string): string {
-  // Note: We need 'unsafe-eval' for Next.js hot module replacement in dev
-  // and for certain third-party scripts like Google Analytics
-  const cspDirectives = [
-    "default-src 'self'",
-    // Script sources: nonce for inline, specific domains for third-party
-    `script-src 'self' 'nonce-${nonce}' 'strict-dynamic' https://www.googletagmanager.com https://www.google-analytics.com`,
-    // Style sources: nonce for inline styles
-    `style-src 'self' 'nonce-${nonce}' fonts.googleapis.com`,
-    "font-src 'self' fonts.gstatic.com",
-    "img-src 'self' data: blob: https:",
-    "media-src 'self'",
-    "object-src 'none'",
-    "base-uri 'self'",
-    "form-action 'self'",
-    "frame-ancestors 'none'",
-    "connect-src 'self' https://www.google-analytics.com https://analytics.google.com https://region1.google-analytics.com",
-    "upgrade-insecure-requests",
-  ];
-
-  return cspDirectives.join("; ");
-}
-
-/**
  * Async middleware with Redis-backed rate limiting and nonce-based CSP
  */
 export async function middleware(request: NextRequest) {
@@ -193,7 +168,7 @@ export async function middleware(request: NextRequest) {
   );
 
   // Add nonce-based Content Security Policy
-  response.headers.set("Content-Security-Policy", buildCSPHeader(nonce));
+  response.headers.set("Content-Security-Policy", buildCSPHeader({ nonce }));
 
   return response;
 }

--- a/src/types/portfolio.ts
+++ b/src/types/portfolio.ts
@@ -1,0 +1,136 @@
+export type PortfolioLocale = "en" | "tr" | "es";
+
+export interface PortfolioNavItem {
+  readonly label: string;
+  readonly href: string;
+}
+
+export interface PortfolioHeroContent {
+  readonly eyebrow: string;
+  readonly availability: string;
+  readonly headline: string;
+  readonly supportingText: string;
+  readonly primaryCta: string;
+  readonly secondaryCta: string;
+  readonly techTags: readonly string[];
+}
+
+export interface PortfolioAboutContent {
+  readonly sectionNumber: string;
+  readonly sectionTitle: string;
+  readonly lead: string;
+  readonly paragraphs: readonly string[];
+  readonly statusPill: string;
+}
+
+export interface PortfolioExperienceItem {
+  readonly number: string;
+  readonly company: string;
+  readonly role: string;
+  readonly period: string;
+  readonly location: string;
+  readonly description: string;
+  readonly tags: readonly string[];
+}
+
+export interface PortfolioProjectItem {
+  readonly number: string;
+  readonly name: string;
+  readonly company: string;
+  readonly description: string;
+  readonly themes: readonly string[];
+  readonly tags: readonly string[];
+}
+
+export interface PortfolioCapabilityGroup {
+  readonly category: string;
+  readonly items: readonly string[];
+}
+
+export interface PortfolioContactFormCopy {
+  readonly nameLabel: string;
+  readonly emailLabel: string;
+  readonly subjectLabel: string;
+  readonly messageLabel: string;
+  readonly submitLabel: string;
+  readonly submittingLabel: string;
+  readonly placeholders: {
+    readonly name: string;
+    readonly email: string;
+    readonly subject: string;
+    readonly message: string;
+  };
+  readonly validation: {
+    readonly nameRequired: string;
+    readonly emailInvalid: string;
+    readonly subjectRequired: string;
+    readonly messageRequired: string;
+    readonly messageMinLength: string;
+  };
+  readonly success: string;
+  readonly securityLoading: string;
+  readonly secured: string;
+  readonly blocked: string;
+}
+
+export interface PortfolioContactContent {
+  readonly sectionNumber: string;
+  readonly sectionTitle: string;
+  readonly headline: string;
+  readonly intro: string;
+  readonly body: string;
+  readonly form: PortfolioContactFormCopy;
+}
+
+export interface PortfolioFooterContent {
+  readonly strapline: string;
+  readonly copyright: string;
+}
+
+export interface PortfolioNotFoundContent {
+  readonly eyebrow: string;
+  readonly title: string;
+  readonly description: string;
+  readonly primaryCta: string;
+  readonly secondaryCta: string;
+}
+
+export interface PortfolioContent {
+  readonly locale: PortfolioLocale;
+  readonly metadata: {
+    readonly title: string;
+    readonly description: string;
+  };
+  readonly nav: {
+    readonly homeLabel: string;
+    readonly items: readonly PortfolioNavItem[];
+    readonly languageLabel: string;
+    readonly letsTalkLabel: string;
+    readonly closeMenuLabel: string;
+    readonly openMenuLabel: string;
+  };
+  readonly hero: PortfolioHeroContent;
+  readonly about: PortfolioAboutContent;
+  readonly experience: {
+    readonly sectionNumber: string;
+    readonly sectionTitle: string;
+    readonly intro: string;
+    readonly items: readonly PortfolioExperienceItem[];
+  };
+  readonly projects: {
+    readonly sectionNumber: string;
+    readonly sectionTitle: string;
+    readonly intro: string;
+    readonly items: readonly PortfolioProjectItem[];
+  };
+  readonly capabilities: {
+    readonly sectionNumber: string;
+    readonly sectionTitle: string;
+    readonly groups: readonly PortfolioCapabilityGroup[];
+    readonly callout: string;
+    readonly statLabel: string;
+  };
+  readonly contact: PortfolioContactContent;
+  readonly footer: PortfolioFooterContent;
+  readonly notFound: PortfolioNotFoundContent;
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
     environment: "jsdom",
     setupFiles: ["./vitest.setup.ts"],
     include: ["**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}"],
-    exclude: ["node_modules", ".next", "out", "build"],
+    exclude: ["node_modules", ".next", "out", "build", "e2e/**"],
     coverage: {
       provider: "v8",
       reporter: ["text", "json", "html"],


### PR DESCRIPTION
## Summary
- port the Figma redesign into the real Next.js portfolio surface instead of replacing the production app architecture
- ship a focused editorial portfolio with real English and Turkish routes, updated metadata/sitemap/structured-data, and Spanish hidden from the public surface for now
- preserve the production contact and security flow while redesigning the UI, add generated social preview images, and address review feedback around form reset behavior and canonical URL consistency

## Test Plan
- [x] npm run lint
- [x] npm run type-check
- [x] npm run test:run
- [x] npm run e2e
- [x] npm run build
