### PR TITLE
feat: add light and dark theme support to redesigned portfolio

### DIFF
--- a/e2e/theme.spec.ts
+++ b/e2e/theme.spec.ts
@@ -7,11 +7,44 @@ test.describe("Redesign shell", () => {
     await mockCsrfToken(page);
   });
 
-  test("does not expose the legacy theme toggle", async ({ page }) => {
+  test("does not expose the legacy theme toggle and defaults to the dark theme", async ({
+    page,
+  }) => {
+    await page.addInitScript(() => {
+      window.localStorage.removeItem("aty-theme");
+    });
     await page.goto("/");
 
     await expect(page.locator(".theme-toggle")).toHaveCount(0);
     await expect(page.locator("html")).not.toHaveClass(/matrix|starwars/);
+    await expect(page.locator("html")).toHaveClass(/dark-theme/);
+    await expect(page.locator('meta[name="theme-color"]')).toHaveAttribute(
+      "content",
+      "#080808"
+    );
+  });
+
+  test("persists the light theme across reloads and 404 routes", async ({ page }) => {
+    await page.goto("/");
+
+    await page.getByRole("button", { name: /switch to light theme/i }).first().click();
+
+    await expect(page.locator("html")).toHaveClass(/light-theme/);
+    await expect(page.locator('meta[name="theme-color"]')).toHaveAttribute(
+      "content",
+      "#F4F2ED"
+    );
+
+    await page.reload();
+    await expect(page.locator("html")).toHaveClass(/light-theme/);
+
+    await page.goto("/missing-route");
+    await expect(
+      page.getByRole("button", { name: /switch to dark theme/i })
+    ).toBeVisible();
+
+    await page.goto("/tr/olmayan-sayfa");
+    await expect(page.locator("html")).toHaveClass(/light-theme/);
   });
 
   test("renders the redesigned 404 page", async ({ page }) => {
@@ -29,5 +62,26 @@ test.describe("Redesign shell", () => {
     await expect(
       page.getByRole("heading", { name: /Rota bulunamadı\./i })
     ).toBeVisible();
+  });
+
+  test("uses the redesign light backdrop tint on the scrolled header", async ({
+    page,
+  }) => {
+    await page.addInitScript(() => {
+      window.localStorage.setItem("aty-theme", "light");
+    });
+    await page.goto("/");
+
+    await page.evaluate(() => {
+      window.scrollTo(0, 500);
+    });
+
+    await expect
+      .poll(async () =>
+        page.locator("header").evaluate((element) => {
+          return window.getComputedStyle(element).backgroundColor;
+        })
+      )
+      .toBe("rgba(244, 242, 237, 0.96)");
   });
 });

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5,14 +5,54 @@
   --foreground: #f0ede8;
   --surface: #111111;
   --surface-2: #171717;
-  --muted: #9b9b9b;
-  --faint: #4b4b4b;
+  --muted: #6b6b6b;
+  --faint: #2e2e2e;
   --border: #1e1e1e;
-  --border-strong: #2c2c2c;
+  --border-strong: #2a2a2a;
   --accent: #c8ff47;
+  --accent-hover: #daff5a;
   --accent-foreground: #080808;
-  --error: #ff6a6a;
+  --error: #ff5454;
+  --accent-bg: rgba(200, 255, 71, 0.07);
+  --accent-border: rgba(200, 255, 71, 0.25);
+  --error-bg: rgba(255, 84, 84, 0.07);
+  --selection-bg: rgba(200, 255, 71, 0.24);
+  --placeholder: #6b6b6b;
+  --body-glow: rgba(200, 255, 71, 0.06);
+  --grid-dot: #1c1c1c;
+  --surface-overlay: rgba(255, 255, 255, 0.02);
+  --focus-border: rgba(200, 255, 71, 0.55);
+  --focus-ring: rgba(200, 255, 71, 0.12);
+  --error-border: rgba(255, 84, 84, 0.55);
+  --error-ring: rgba(255, 84, 84, 0.12);
   --radius: 1.5rem;
+}
+
+html.light-theme {
+  --background: #f4f2ed;
+  --foreground: #100e0b;
+  --surface: #eceae4;
+  --surface-2: #e3e1da;
+  --muted: #6c6558;
+  --faint: #b0aa9f;
+  --border: #d4d0c8;
+  --border-strong: #c0bab1;
+  --accent: #4a7a00;
+  --accent-hover: #3a6200;
+  --accent-foreground: #f4f2ed;
+  --error: #c41c1c;
+  --accent-bg: rgba(74, 122, 0, 0.07);
+  --accent-border: rgba(74, 122, 0, 0.22);
+  --error-bg: rgba(196, 28, 28, 0.07);
+  --selection-bg: rgba(74, 122, 0, 0.16);
+  --placeholder: #a0998f;
+  --body-glow: rgba(74, 122, 0, 0.06);
+  --grid-dot: #ceccbf;
+  --surface-overlay: rgba(16, 14, 11, 0.02);
+  --focus-border: rgba(74, 122, 0, 0.45);
+  --focus-ring: rgba(74, 122, 0, 0.12);
+  --error-border: rgba(196, 28, 28, 0.45);
+  --error-ring: rgba(196, 28, 28, 0.12);
 }
 
 @theme inline {
@@ -36,15 +76,21 @@
 html {
   background: var(--background);
   color: var(--foreground);
+  transition:
+    background-color 300ms ease,
+    color 300ms ease;
 }
 
 body {
   min-height: 100vh;
   background:
-    radial-gradient(circle at top, rgba(200, 255, 71, 0.06), transparent 35%),
+    radial-gradient(circle at top, var(--body-glow), transparent 35%),
     var(--background);
   color: var(--foreground);
   font-family: var(--font-space-grotesk), system-ui, sans-serif;
+  transition:
+    background-color 300ms ease,
+    color 300ms ease;
 }
 
 a,
@@ -66,12 +112,12 @@ textarea {
 }
 
 ::selection {
-  background: rgba(200, 255, 71, 0.24);
+  background: var(--selection-bg);
   color: var(--foreground);
 }
 
 ::placeholder {
-  color: var(--muted);
+  color: var(--placeholder);
 }
 
 .skip-link {
@@ -94,7 +140,7 @@ textarea {
 }
 
 .shell-grid {
-  background-image: radial-gradient(circle, rgba(255, 255, 255, 0.08) 1px, transparent 1px);
+  background-image: radial-gradient(circle, var(--grid-dot) 1px, transparent 1px);
   background-size: 28px 28px;
 }
 
@@ -127,7 +173,7 @@ textarea {
   align-items: center;
   border-radius: 999px;
   border: 1px solid var(--border);
-  background: rgba(255, 255, 255, 0.02);
+  background: var(--surface-overlay);
   padding: 0.35rem 0.7rem;
   font-family: var(--font-jetbrains-mono), monospace;
   font-size: 0.7rem;
@@ -139,8 +185,8 @@ textarea {
   display: inline-flex;
   align-items: center;
   border-radius: 999px;
-  border: 1px solid rgba(200, 255, 71, 0.25);
-  background: rgba(200, 255, 71, 0.09);
+  border: 1px solid var(--accent-border);
+  background: var(--accent-bg);
   padding: 0.35rem 0.7rem;
   font-family: var(--font-jetbrains-mono), monospace;
   font-size: 0.7rem;
@@ -193,13 +239,13 @@ textarea {
 
 .input-shell:focus {
   outline: none;
-  border-color: rgba(200, 255, 71, 0.55);
-  box-shadow: 0 0 0 3px rgba(200, 255, 71, 0.12);
+  border-color: var(--focus-border);
+  box-shadow: 0 0 0 3px var(--focus-ring);
 }
 
 .input-shell[aria-invalid="true"] {
-  border-color: rgba(255, 106, 106, 0.55);
-  box-shadow: 0 0 0 3px rgba(255, 106, 106, 0.12);
+  border-color: var(--error-border);
+  box-shadow: 0 0 0 3px var(--error-ring);
 }
 
 .writing-vertical {
@@ -207,7 +253,7 @@ textarea {
 }
 
 :focus-visible {
-  outline: 2px solid rgba(200, 255, 71, 0.55);
+  outline: 2px solid var(--focus-border);
   outline-offset: 2px;
 }
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -77,7 +77,7 @@ html {
   background: var(--background);
   color: var(--foreground);
   transition:
-    background-color 300ms ease,
+    background 300ms ease,
     color 300ms ease;
 }
 
@@ -89,7 +89,7 @@ body {
   color: var(--foreground);
   font-family: var(--font-space-grotesk), system-ui, sans-serif;
   transition:
-    background-color 300ms ease,
+    background 300ms ease,
     color 300ms ease;
 }
 
@@ -213,6 +213,7 @@ textarea {
 }
 
 .primary-button:hover {
+  background: var(--accent-hover);
   transform: translateY(-1px);
 }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,7 +3,9 @@ import { headers } from "next/headers";
 import { JetBrains_Mono, Space_Grotesk } from "next/font/google";
 import { GoogleAnalytics } from "@next/third-parties/google";
 
+import { PortfolioThemeProvider } from "@/components/portfolio/theme";
 import StructuredData from "@/components/utils/StructuredData";
+import { portfolioThemeScript } from "@/lib/portfolio/theme-script";
 import type { PortfolioLocale } from "@/types/portfolio";
 
 import "./globals.css";
@@ -29,6 +31,7 @@ export default async function RootLayout({
 }>) {
   const headersList = await headers();
   const localeHeader = headersList.get("x-locale");
+  const nonce = headersList.get("x-nonce") ?? undefined;
   const requestLocale: PortfolioLocale =
     localeHeader === "tr" || localeHeader === "es" ? localeHeader : "en";
 
@@ -38,6 +41,11 @@ export default async function RootLayout({
         <StructuredData locale={requestLocale} />
         <meta name="format-detection" content="telephone=no" />
         <meta name="theme-color" content="#080808" />
+        <script
+          dangerouslySetInnerHTML={{ __html: portfolioThemeScript }}
+          id="portfolio-theme-script"
+          nonce={nonce}
+        />
         <link rel="icon" href="/favicon.ico" sizes="any" />
         <link rel="icon" type="image/svg+xml" href="/icon.svg" />
         <link rel="apple-touch-icon" href="/favicon.ico" />
@@ -46,10 +54,12 @@ export default async function RootLayout({
       <body
         className={`${spaceGrotesk.variable} ${jetBrainsMono.variable} bg-background text-foreground antialiased`}
       >
-        <a href="#main-content" className="skip-link">
-          Skip to main content
-        </a>
-        {children}
+        <PortfolioThemeProvider>
+          <a href="#main-content" className="skip-link">
+            Skip to main content
+          </a>
+          {children}
+        </PortfolioThemeProvider>
       </body>
       {process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID ? (
         <GoogleAnalytics gaId={process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID} />

--- a/src/components/portfolio/Header.tsx
+++ b/src/components/portfolio/Header.tsx
@@ -6,6 +6,8 @@ import { useEffect, useState } from "react";
 
 import type { PortfolioContent, PortfolioLocale } from "@/types/portfolio";
 
+import { usePortfolioTheme } from "@/components/portfolio/theme";
+
 import { LanguageSwitcher } from "./LanguageSwitcher";
 import { PortfolioThemeToggle } from "./PortfolioThemeToggle";
 
@@ -15,8 +17,12 @@ interface HeaderProps {
 }
 
 export function Header({ nav, locale }: HeaderProps) {
+  const { isDark } = usePortfolioTheme();
   const [isScrolled, setIsScrolled] = useState(false);
   const [isOpen, setIsOpen] = useState(false);
+  const scrolledBackground = isDark
+    ? "rgba(8, 8, 8, 0.96)"
+    : "rgba(244, 242, 237, 0.96)";
 
   useEffect(() => {
     const onScroll = () => setIsScrolled(window.scrollY > 40);
@@ -36,9 +42,10 @@ export function Header({ nav, locale }: HeaderProps) {
       <header
         className={`fixed inset-x-0 top-0 z-50 transition-all duration-300 ${
           isScrolled
-            ? "border-b border-border bg-background/90 backdrop-blur-xl"
+            ? "border-b border-border backdrop-blur-xl"
             : "bg-transparent"
         }`}
+        style={isScrolled ? { backgroundColor: scrolledBackground } : undefined}
       >
         <div className="mx-auto flex h-16 w-full max-w-6xl items-center justify-between px-5 sm:px-8">
           <a href="#hero" className="mono-label text-foreground">

--- a/src/components/portfolio/Header.tsx
+++ b/src/components/portfolio/Header.tsx
@@ -7,6 +7,7 @@ import { useEffect, useState } from "react";
 import type { PortfolioContent, PortfolioLocale } from "@/types/portfolio";
 
 import { LanguageSwitcher } from "./LanguageSwitcher";
+import { PortfolioThemeToggle } from "./PortfolioThemeToggle";
 
 interface HeaderProps {
   nav: PortfolioContent["nav"];
@@ -61,6 +62,7 @@ export function Header({ nav, locale }: HeaderProps) {
               label={nav.languageLabel}
               compact
             />
+            <PortfolioThemeToggle locale={locale} />
             <a href="#contact" className="secondary-button">
               {nav.letsTalkLabel}
             </a>
@@ -72,6 +74,7 @@ export function Header({ nav, locale }: HeaderProps) {
               label={nav.languageLabel}
               compact
             />
+            <PortfolioThemeToggle locale={locale} />
             <button
               type="button"
               className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-border bg-surface text-foreground"

--- a/src/components/portfolio/NotFoundPage.tsx
+++ b/src/components/portfolio/NotFoundPage.tsx
@@ -6,6 +6,8 @@ import { motion } from "framer-motion";
 import { buildLocalizedHref } from "@/lib/i18n/routing";
 import type { PortfolioLocale, PortfolioNotFoundContent } from "@/types/portfolio";
 
+import { PortfolioThemeToggle } from "./PortfolioThemeToggle";
+
 interface NotFoundPageProps {
   content: PortfolioNotFoundContent;
   locale: PortfolioLocale;
@@ -15,6 +17,9 @@ export function NotFoundPage({ content, locale }: NotFoundPageProps) {
   return (
     <div className="relative flex min-h-screen items-center justify-center overflow-hidden px-5 py-24 sm:px-8">
       <div className="absolute inset-0 shell-grid opacity-50" />
+      <div className="absolute right-5 top-6 z-20 sm:right-8">
+        <PortfolioThemeToggle locale={locale} variant="labeled" />
+      </div>
 
       <motion.div
         initial={{ opacity: 0, y: 24 }}

--- a/src/components/portfolio/PortfolioThemeToggle.tsx
+++ b/src/components/portfolio/PortfolioThemeToggle.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { Moon, Sun } from "lucide-react";
+
+import { usePortfolioTheme } from "@/components/portfolio/theme";
+import type { PortfolioLocale } from "@/types/portfolio";
+
+type PortfolioThemeToggleVariant = "icon" | "labeled";
+
+interface PortfolioThemeToggleProps {
+  locale: PortfolioLocale;
+  variant?: PortfolioThemeToggleVariant;
+}
+
+const themeToggleCopy = {
+  en: {
+    lightLabel: "LIGHT",
+    darkLabel: "DARK",
+    switchToLight: "Switch to light theme",
+    switchToDark: "Switch to dark theme",
+  },
+  tr: {
+    lightLabel: "AYDINLIK",
+    darkLabel: "KOYU",
+    switchToLight: "Açık temaya geç",
+    switchToDark: "Koyu temaya geç",
+  },
+  es: {
+    lightLabel: "CLARO",
+    darkLabel: "OSCURO",
+    switchToLight: "Cambiar a tema claro",
+    switchToDark: "Cambiar a tema oscuro",
+  },
+} as const;
+
+export function PortfolioThemeToggle({
+  locale,
+  variant = "icon",
+}: PortfolioThemeToggleProps) {
+  const { isDark, toggleTheme } = usePortfolioTheme();
+  const copy = themeToggleCopy[locale];
+  const label = isDark ? copy.lightLabel : copy.darkLabel;
+  const ariaLabel = isDark ? copy.switchToLight : copy.switchToDark;
+  const Icon = isDark ? Sun : Moon;
+
+  if (variant === "labeled") {
+    return (
+      <button
+        type="button"
+        aria-label={ariaLabel}
+        className="inline-flex items-center gap-2 rounded-full border border-border bg-transparent px-3.5 py-2 font-[var(--font-jetbrains-mono)] text-[11px] tracking-[0.08em] text-muted-foreground transition-colors hover:border-border-strong hover:bg-surface hover:text-foreground"
+        onClick={toggleTheme}
+      >
+        <Icon size={12} />
+        <span>{label}</span>
+      </button>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      aria-label={ariaLabel}
+      className="inline-flex h-8 w-8 items-center justify-center rounded-[10px] border border-border bg-transparent text-muted-foreground transition-colors hover:border-border-strong hover:bg-surface hover:text-foreground"
+      onClick={toggleTheme}
+    >
+      <Icon size={13} />
+    </button>
+  );
+}

--- a/src/components/portfolio/ThemeControls.test.tsx
+++ b/src/components/portfolio/ThemeControls.test.tsx
@@ -5,6 +5,7 @@ import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { getPortfolioContent } from "@/lib/content/portfolio";
+import { PORTFOLIO_THEME_STORAGE_KEY } from "@/lib/portfolio/theme";
 
 import { Header } from "./Header";
 import { NotFoundPage } from "./NotFoundPage";
@@ -42,7 +43,7 @@ describe("portfolio theme controls", () => {
     await user.click(toggles[0]);
 
     expect(document.documentElement).toHaveClass("light-theme");
-    expect(localStorage.getItem("aty-theme")).toBe("light");
+    expect(localStorage.getItem(PORTFOLIO_THEME_STORAGE_KEY)).toBe("light");
   });
 
   it("renders the labeled 404 toggle in the redesigned top-right position", () => {

--- a/src/components/portfolio/ThemeControls.test.tsx
+++ b/src/components/portfolio/ThemeControls.test.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getPortfolioContent } from "@/lib/content/portfolio";
+
+import { Header } from "./Header";
+import { NotFoundPage } from "./NotFoundPage";
+import { PortfolioThemeProvider } from "./theme";
+
+vi.mock("./LanguageSwitcher", () => ({
+  LanguageSwitcher: () => <div data-testid="language-switcher" />,
+}));
+
+describe("portfolio theme controls", () => {
+  const content = getPortfolioContent("en");
+
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.className = "dark-theme";
+    document.head.innerHTML = '<meta name="theme-color" content="#080808" />';
+  });
+
+  it("keeps the language switcher and adds theme toggles to the header", async () => {
+    render(
+      <PortfolioThemeProvider>
+        <Header nav={content.nav} locale="en" />
+      </PortfolioThemeProvider>
+    );
+
+    expect(screen.getAllByTestId("language-switcher")).toHaveLength(2);
+
+    const toggles = screen.getAllByRole("button", {
+      name: /switch to light theme/i,
+    });
+
+    expect(toggles).toHaveLength(2);
+
+    const user = userEvent.setup();
+    await user.click(toggles[0]);
+
+    expect(document.documentElement).toHaveClass("light-theme");
+    expect(localStorage.getItem("aty-theme")).toBe("light");
+  });
+
+  it("renders the labeled 404 toggle in the redesigned top-right position", () => {
+    render(
+      <PortfolioThemeProvider>
+        <NotFoundPage content={content.notFound} locale="en" />
+      </PortfolioThemeProvider>
+    );
+
+    expect(
+      screen.getByRole("button", { name: /switch to light theme/i })
+    ).toBeVisible();
+    expect(screen.getByText("LIGHT")).toBeVisible();
+  });
+});

--- a/src/components/portfolio/theme/PortfolioThemeProvider.test.tsx
+++ b/src/components/portfolio/theme/PortfolioThemeProvider.test.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { PortfolioThemeProvider, usePortfolioTheme } from "./PortfolioThemeProvider";
+import {
+  PORTFOLIO_THEME_COLOR,
+  PORTFOLIO_THEME_STORAGE_KEY,
+} from "@/lib/portfolio/theme";
+
+function ThemeHarness() {
+  const { isDark, toggleTheme } = usePortfolioTheme();
+
+  return (
+    <button type="button" onClick={toggleTheme}>
+      {isDark ? "dark" : "light"}
+    </button>
+  );
+}
+
+describe("PortfolioThemeProvider", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.className = "";
+    document.head.innerHTML = '<meta name="theme-color" content="#080808" />';
+  });
+
+  it("defaults to the dark portfolio theme", () => {
+    render(
+      <PortfolioThemeProvider>
+        <ThemeHarness />
+      </PortfolioThemeProvider>
+    );
+
+    expect(screen.getByRole("button", { name: "dark" })).toBeVisible();
+    expect(document.documentElement).toHaveClass("dark-theme");
+    expect(document.documentElement).not.toHaveClass("light-theme");
+    expect(localStorage.getItem(PORTFOLIO_THEME_STORAGE_KEY)).toBe("dark");
+    expect(
+      document.querySelector('meta[name="theme-color"]')
+    ).toHaveAttribute("content", PORTFOLIO_THEME_COLOR.dark);
+  });
+
+  it("hydrates from the stored theme", () => {
+    localStorage.setItem(PORTFOLIO_THEME_STORAGE_KEY, "light");
+
+    render(
+      <PortfolioThemeProvider>
+        <ThemeHarness />
+      </PortfolioThemeProvider>
+    );
+
+    expect(screen.getByRole("button", { name: "light" })).toBeVisible();
+    expect(document.documentElement).toHaveClass("light-theme");
+    expect(document.documentElement).not.toHaveClass("dark-theme");
+    expect(
+      document.querySelector('meta[name="theme-color"]')
+    ).toHaveAttribute("content", PORTFOLIO_THEME_COLOR.light);
+  });
+
+  it("toggles the theme, persistence, and theme-color together", async () => {
+    render(
+      <PortfolioThemeProvider>
+        <ThemeHarness />
+      </PortfolioThemeProvider>
+    );
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: "dark" }));
+
+    expect(screen.getByRole("button", { name: "light" })).toBeVisible();
+    expect(document.documentElement).toHaveClass("light-theme");
+    expect(localStorage.getItem(PORTFOLIO_THEME_STORAGE_KEY)).toBe("light");
+    expect(
+      document.querySelector('meta[name="theme-color"]')
+    ).toHaveAttribute("content", PORTFOLIO_THEME_COLOR.light);
+  });
+});

--- a/src/components/portfolio/theme/PortfolioThemeProvider.tsx
+++ b/src/components/portfolio/theme/PortfolioThemeProvider.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+
+import {
+  PORTFOLIO_THEME_STORAGE_KEY,
+  applyPortfolioTheme,
+  getStoredPortfolioTheme,
+  type PortfolioTheme,
+} from "@/lib/portfolio/theme";
+
+interface PortfolioThemeContextValue {
+  readonly theme: PortfolioTheme;
+  readonly isDark: boolean;
+  readonly toggleTheme: () => void;
+  readonly setTheme: (theme: PortfolioTheme) => void;
+}
+
+const PortfolioThemeContext = createContext<
+  PortfolioThemeContextValue | undefined
+>(undefined);
+
+function getInitialTheme(): PortfolioTheme {
+  if (typeof document !== "undefined") {
+    if (document.documentElement.classList.contains("light-theme")) {
+      return "light";
+    }
+
+    if (document.documentElement.classList.contains("dark-theme")) {
+      return "dark";
+    }
+  }
+
+  return getStoredPortfolioTheme();
+}
+
+export function PortfolioThemeProvider({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  const [theme, setThemeState] = useState<PortfolioTheme>(getInitialTheme);
+
+  useEffect(() => {
+    applyPortfolioTheme(theme);
+
+    try {
+      window.localStorage.setItem(PORTFOLIO_THEME_STORAGE_KEY, theme);
+    } catch {
+      // Storage access can fail in hardened browsers; keep the active DOM theme.
+    }
+  }, [theme]);
+
+  const setTheme = useCallback((nextTheme: PortfolioTheme) => {
+    setThemeState(nextTheme);
+  }, []);
+
+  const toggleTheme = useCallback(() => {
+    setThemeState((currentTheme) =>
+      currentTheme === "dark" ? "light" : "dark"
+    );
+  }, []);
+
+  const contextValue = useMemo(
+    () => ({
+      theme,
+      isDark: theme === "dark",
+      toggleTheme,
+      setTheme,
+    }),
+    [setTheme, theme, toggleTheme]
+  );
+
+  return (
+    <PortfolioThemeContext.Provider value={contextValue}>
+      {children}
+    </PortfolioThemeContext.Provider>
+  );
+}
+
+export function usePortfolioTheme() {
+  const context = useContext(PortfolioThemeContext);
+
+  if (!context) {
+    throw new Error(
+      "usePortfolioTheme must be used within a PortfolioThemeProvider"
+    );
+  }
+
+  return context;
+}

--- a/src/components/portfolio/theme/PortfolioThemeProvider.tsx
+++ b/src/components/portfolio/theme/PortfolioThemeProvider.tsx
@@ -10,6 +10,7 @@ import {
 } from "react";
 
 import {
+  PORTFOLIO_THEME_CLASS,
   PORTFOLIO_THEME_STORAGE_KEY,
   applyPortfolioTheme,
   getStoredPortfolioTheme,
@@ -29,11 +30,19 @@ const PortfolioThemeContext = createContext<
 
 function getInitialTheme(): PortfolioTheme {
   if (typeof document !== "undefined") {
-    if (document.documentElement.classList.contains("light-theme")) {
+    if (
+      document.documentElement.classList.contains(
+        PORTFOLIO_THEME_CLASS.light
+      )
+    ) {
       return "light";
     }
 
-    if (document.documentElement.classList.contains("dark-theme")) {
+    if (
+      document.documentElement.classList.contains(
+        PORTFOLIO_THEME_CLASS.dark
+      )
+    ) {
       return "dark";
     }
   }

--- a/src/components/portfolio/theme/index.ts
+++ b/src/components/portfolio/theme/index.ts
@@ -1,0 +1,4 @@
+export {
+  PortfolioThemeProvider,
+  usePortfolioTheme,
+} from "./PortfolioThemeProvider";

--- a/src/lib/portfolio/theme-script.ts
+++ b/src/lib/portfolio/theme-script.ts
@@ -1,0 +1,31 @@
+import {
+  PORTFOLIO_THEME_CLASS,
+  PORTFOLIO_THEME_COLOR,
+  PORTFOLIO_THEME_STORAGE_KEY,
+} from "./theme";
+
+export const portfolioThemeScript = `
+(function() {
+  try {
+    var storedTheme = window.localStorage.getItem(${JSON.stringify(PORTFOLIO_THEME_STORAGE_KEY)});
+    var theme = storedTheme === "light" ? "light" : "dark";
+    var root = document.documentElement;
+    root.classList.remove(${JSON.stringify(PORTFOLIO_THEME_CLASS.dark)}, ${JSON.stringify(PORTFOLIO_THEME_CLASS.light)});
+    root.classList.add(theme === "light" ? ${JSON.stringify(PORTFOLIO_THEME_CLASS.light)} : ${JSON.stringify(PORTFOLIO_THEME_CLASS.dark)});
+    root.style.colorScheme = theme;
+    var themeColorMeta = document.querySelector('meta[name="theme-color"]');
+    if (themeColorMeta) {
+      themeColorMeta.setAttribute("content", theme === "light" ? ${JSON.stringify(PORTFOLIO_THEME_COLOR.light)} : ${JSON.stringify(PORTFOLIO_THEME_COLOR.dark)});
+    }
+  } catch {
+    var root = document.documentElement;
+    root.classList.remove(${JSON.stringify(PORTFOLIO_THEME_CLASS.light)});
+    root.classList.add(${JSON.stringify(PORTFOLIO_THEME_CLASS.dark)});
+    root.style.colorScheme = "dark";
+    var themeColorMeta = document.querySelector('meta[name="theme-color"]');
+    if (themeColorMeta) {
+      themeColorMeta.setAttribute("content", ${JSON.stringify(PORTFOLIO_THEME_COLOR.dark)});
+    }
+  }
+})();
+`;

--- a/src/lib/portfolio/theme.ts
+++ b/src/lib/portfolio/theme.ts
@@ -1,0 +1,49 @@
+export type PortfolioTheme = "dark" | "light";
+
+export const PORTFOLIO_THEME_STORAGE_KEY = "aty-theme";
+
+export const PORTFOLIO_THEME_CLASS: Record<PortfolioTheme, string> = {
+  dark: "dark-theme",
+  light: "light-theme",
+};
+
+export const PORTFOLIO_THEME_COLOR: Record<PortfolioTheme, string> = {
+  dark: "#080808",
+  light: "#F4F2ED",
+};
+
+export function isPortfolioTheme(value: unknown): value is PortfolioTheme {
+  return value === "dark" || value === "light";
+}
+
+export function getStoredPortfolioTheme(): PortfolioTheme {
+  if (typeof window === "undefined") {
+    return "dark";
+  }
+
+  try {
+    const storedTheme = window.localStorage.getItem(PORTFOLIO_THEME_STORAGE_KEY);
+    return isPortfolioTheme(storedTheme) ? storedTheme : "dark";
+  } catch {
+    return "dark";
+  }
+}
+
+export function applyPortfolioTheme(
+  theme: PortfolioTheme,
+  doc: Document = document
+) {
+  const root = doc.documentElement;
+
+  root.classList.remove(
+    PORTFOLIO_THEME_CLASS.dark,
+    PORTFOLIO_THEME_CLASS.light
+  );
+  root.classList.add(PORTFOLIO_THEME_CLASS[theme]);
+  root.style.colorScheme = theme;
+
+  const themeColorMeta = doc.querySelector('meta[name="theme-color"]');
+  if (themeColorMeta) {
+    themeColorMeta.setAttribute("content", PORTFOLIO_THEME_COLOR[theme]);
+  }
+}

--- a/src/lib/request-context.test.ts
+++ b/src/lib/request-context.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+
+import { buildRequestContextHeaders } from "./request-context";
+
+describe("buildRequestContextHeaders", () => {
+  it("adds locale, pathname, and nonce to the server-readable request headers", () => {
+    const requestHeaders = buildRequestContextHeaders(
+      new Headers([["accept", "text/html"]]),
+      "/tr/projects",
+      "nonce-123"
+    );
+
+    expect(requestHeaders.get("accept")).toBe("text/html");
+    expect(requestHeaders.get("x-locale")).toBe("tr");
+    expect(requestHeaders.get("x-pathname")).toBe("/tr/projects");
+    expect(requestHeaders.get("x-nonce")).toBe("nonce-123");
+  });
+});

--- a/src/lib/request-context.ts
+++ b/src/lib/request-context.ts
@@ -1,0 +1,15 @@
+import { getLocaleFromPathname } from "@/lib/i18n/routing";
+
+export function buildRequestContextHeaders(
+  incomingHeaders: Headers,
+  pathname: string,
+  nonce: string
+) {
+  const requestHeaders = new Headers(incomingHeaders);
+
+  requestHeaders.set("x-locale", getLocaleFromPathname(pathname));
+  requestHeaders.set("x-pathname", pathname);
+  requestHeaders.set("x-nonce", nonce);
+
+  return requestHeaders;
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -6,7 +6,7 @@ import {
   getRateLimitingMethod,
 } from "@/lib/redis-rate-limit";
 import { buildCSPHeader } from "@/lib/csp";
-import { getLocaleFromPathname } from "@/lib/i18n/routing";
+import { buildRequestContextHeaders } from "@/lib/request-context";
 import type { RateLimitConfig } from "@/types";
 
 // Rate limiting configuration per endpoint
@@ -133,18 +133,17 @@ export async function middleware(request: NextRequest) {
   // Generate nonce for CSP
   const nonce = generateNonce();
 
-  const requestHeaders = new Headers(request.headers);
-  requestHeaders.set("x-locale", getLocaleFromPathname(pathname));
-  requestHeaders.set("x-pathname", pathname);
+  const requestHeaders = buildRequestContextHeaders(
+    request.headers,
+    pathname,
+    nonce
+  );
 
   const response = NextResponse.next({
     request: {
       headers: requestHeaders,
     },
   });
-
-  // Pass nonce to the application via header (will be read by layout.tsx)
-  response.headers.set("x-nonce", nonce);
 
   // Add security headers
   response.headers.set("X-Content-Type-Options", "nosniff");


### PR DESCRIPTION
## Summary
- add a portfolio-only dark/light theme foundation with pre-hydration bootstrapping and redesign token parity
- add theme toggles to the redesigned header and 404 shell without changing layout composition
- extend browser coverage for theme persistence, 404 behavior, and the scrolled header tint

## Test Plan
- pnpm lint
- pnpm type-check
- pnpm test:run
- pnpm e2e